### PR TITLE
feat: start sketching out netcore

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,35 @@
+# This workflow builds and tests a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        goversion:
+          # The first entry of the matrix should be the
+          # version indicated inside the `go.mod`
+          - "1.23"
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "${{ matrix.goversion }}"
+
+    - name: Build
+      run: go build ./...
+
+    - name: Test
+      run: go test -race -cover ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rbmk-project/x
+
+go 1.23.3

--- a/netcore/dialer.go
+++ b/netcore/dialer.go
@@ -14,7 +14,7 @@ import (
 //
 // A [*Dialer] is safe for concurrent use by multiple goroutines
 // as long as you don't modify its fields after construction and the
-// underlying fields you may set (e.g., DialContext) are also safe.
+// underlying fields you may set (e.g., DialContextFunc) are also safe.
 type Dialer struct {
 	// DialContextFunc is the optional dialer for creating new
 	// TCP and UDP connections. If this field is nil, the default

--- a/netcore/dialer.go
+++ b/netcore/dialer.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore
+
+import (
+	"context"
+	"log/slog"
+	"net"
+)
+
+// Dialer dials TCP/UDP connections.
+//
+// Construct using [NewDialer].
+//
+// A [*Dialer] is safe for concurrent use by multiple goroutines
+// as long as you don't modify its fields after construction and the
+// underlying fields you may set (e.g., DialContext) are also safe.
+type Dialer struct {
+	// DialContextFunc is the optional dialer for creating new
+	// TCP and UDP connections. If this field is nil, the default
+	// dialer from the [net] package will be used.
+	DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// Logger is the optional structured logger for emitting
+	// structured diagnostic events. If this field is nil, we
+	// will not be emitting structured logs.
+	Logger *slog.Logger
+}
+
+// NewDialer constructs a new [*Dialer] with default settings.
+func NewDialer() *Dialer {
+	return &Dialer{}
+}
+
+// DefaultDialer is the default [*Dialer] used by this package.
+var DefaultDialer = NewDialer()
+
+// DialContext establishes a new TCP/UDP connection.
+func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// TODO(bassosimone): decouple DNS lookup and dialing
+	child := &net.Dialer{}
+	child.SetMultipathTCP(false)
+	return child.DialContext(ctx, network, address)
+}

--- a/netcore/doc.go
+++ b/netcore/doc.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+Package netcore provides a TCP/UDP dialer and a TLS dialer.
+
+This package is designed to facilitate measuring TCP, UDP, and TLS
+connection events via the [log/slog] package.
+
+# Features
+
+- TCP/UDP dialer compatible with the [*net.Dialer];
+
+- TLS dialer compatible with the [*tls.Dialer].
+
+# Design Documents
+
+This package is experimental and has no design documents for now.
+*/
+package netcore

--- a/netcore/integration_test.go
+++ b/netcore/integration_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rbmk-project/x/netcore"
+)
+
+func TestDialerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
+
+	dialer := netcore.NewDialer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, err := dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn.Close()
+}
+
+func TestTLSDialerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip test in short mode")
+	}
+
+	dialer := netcore.NewTLSDialer()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, err := dialer.DialContext(ctx, "tcp", "example.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn.Close()
+}

--- a/netcore/tlsconfig.go
+++ b/netcore/tlsconfig.go
@@ -7,6 +7,8 @@ import (
 	"net"
 )
 
+// newTLSConfig is a best-effort attempt at creating a suitable TLS config
+// for TCP and UDP transports using the network and address.
 func newTLSConfig(network, address string) (*tls.Config, error) {
 	sni, port, err := net.SplitHostPort(address)
 	if err != nil {

--- a/netcore/tlsconfig.go
+++ b/netcore/tlsconfig.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+func newTLSConfig(network, address string) (*tls.Config, error) {
+	sni, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &tls.Config{
+		RootCAs:    nil, // TODO(bassosimone): bundle Mozilla CA store
+		NextProtos: []string{},
+		ServerName: sni,
+	}
+	switch {
+	case port == "443" && network == "tcp":
+		config.NextProtos = []string{"h2", "http/1.1"}
+	case port == "443" && network == "udp":
+		config.NextProtos = []string{"h3"}
+	case port == "853" && network == "tcp":
+		config.NextProtos = []string{"doh"}
+	}
+
+	return config, nil
+}

--- a/netcore/tlsdialer.go
+++ b/netcore/tlsdialer.go
@@ -18,8 +18,8 @@ import (
 // may set (e.g., DialContextFunc) are also safe.
 type TLSDialer struct {
 	// Config is the TLS client config to use. If this field is nil, we
-	// will try to create a suitable config based on the address that is
-	// passed to the DialContext function.
+	// will try to create a suitable config based on the network and address
+	// that are passed to the DialContext method.
 	Config *tls.Config
 
 	// DialContextFunc is the optional dialer for creating new TCP and UDP

--- a/netcore/tlsdialer.go
+++ b/netcore/tlsdialer.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+)
+
+// TLSDialer dials TLS connections.
+//
+// Construct using [NewTLSDialer].
+//
+// A [*TLSDialer] is safe for concurrent use by multiple goroutines as long as
+// you don't modify its fields after construction and the underlying fields you
+// may set (e.g., DialContextFunc) are also safe.
+type TLSDialer struct {
+	// Config is the TLS client config to use. If this field is nil, we
+	// will try to create a suitable config based on the address that is
+	// passed to the DialContext function.
+	Config *tls.Config
+
+	// DialContextFunc is the optional dialer for creating new TCP and UDP
+	// connections. If this field is nil, we use [DefaultDialer].
+	DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// Logger is the optional structured logger for emitting
+	// structured diagnostic events. If this field is nil, we
+	// will not be emitting structured logs.
+	Logger *slog.Logger
+}
+
+// NewTLSDialer constructs a new [*TLSDialer] with default settings.
+func NewTLSDialer() *TLSDialer {
+	return &TLSDialer{}
+}
+
+// DialContext establishes a new TLS connection.
+func (td *TLSDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	config, err := td.config(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(bassosimone): we should use DialContextFunc instead,
+	// which means we need to manually dial here
+	child := &tls.Dialer{Config: config}
+
+	return child.DialContext(ctx, network, address)
+}
+
+func (td *TLSDialer) config(network, address string) (*tls.Config, error) {
+	if td.Config != nil {
+		config := td.Config.Clone() // make sure we return a cloned config
+		return config, nil
+	}
+	return newTLSConfig(network, address)
+}


### PR DESCRIPTION
The netcore package will provide TCP/UDP and TLS dialing. In this initial implementation, we only focus on writing correct documentation and implementing the basic functionality, which we test through integration tests.