### PR TITLE
refactor(netcore): Dialer+TLSDialer = Network

### DIFF
--- a/netcore/dialer.go
+++ b/netcore/dialer.go
@@ -11,44 +11,11 @@ package netcore
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net"
 )
 
-// Dialer dials TCP/UDP connections.
-//
-// Construct using [NewDialer].
-//
-// A [*Dialer] is safe for concurrent use by multiple goroutines
-// as long as you don't modify its fields after construction and the
-// underlying fields you may set (e.g., DialContextFunc) are also safe.
-type Dialer struct {
-	// DialContextFunc is the optional dialer for creating new
-	// TCP and UDP connections. If this field is nil, the default
-	// dialer from the [net] package will be used.
-	DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
-
-	// Logger is the optional structured logger for emitting
-	// structured diagnostic events. If this field is nil, we
-	// will not be emitting structured logs.
-	Logger *slog.Logger
-
-	// LookupHostFunc is the optional function to resolve a domain
-	// name to IP addresses. If this field is nil, we use the
-	// default [*net.Resolver] from the [net] package.
-	LookupHostFunc func(ctx context.Context, domain string) ([]string, error)
-}
-
-// NewDialer constructs a new [*Dialer] with default settings.
-func NewDialer() *Dialer {
-	return &Dialer{}
-}
-
-// DefaultDialer is the default [*Dialer] used by this package.
-var DefaultDialer = NewDialer()
-
 // DialContext establishes a new TCP/UDP connection.
-func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+func (nx *Network) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	// TODO(bassosimone): decide whether we want an overall timeout here
 
 	// resolve the domain name to IP addresses
@@ -56,7 +23,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 	if err != nil {
 		return nil, err
 	}
-	addrs, err := d.maybeLookupHost(ctx, domain)
+	addrs, err := nx.maybeLookupHost(ctx, domain)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +34,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 	var errv []error
 	for _, addr := range addrs {
 		address = net.JoinHostPort(addr, port)
-		conn, err := d.dialLog(ctx, network, address)
+		conn, err := nx.dialLog(ctx, network, address)
 		if conn != nil && err == nil {
 			return conn, nil
 		}
@@ -78,7 +45,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 
 // maybeLookupHost resolves a domain name to IP addresses unless the domain
 // is already an IP address, in which case we short circuit the lookup.
-func (d *Dialer) maybeLookupHost(ctx context.Context, domain string) ([]string, error) {
+func (nx *Network) maybeLookupHost(ctx context.Context, domain string) ([]string, error) {
 	// handle the case where domain is already an IP address
 	if net.ParseIP(domain) != nil {
 		return []string{domain}, nil
@@ -86,13 +53,13 @@ func (d *Dialer) maybeLookupHost(ctx context.Context, domain string) ([]string, 
 
 	// TODO(bassosimone): we should probably ensure we nonetheless
 	// include the lookup event inside the logs.
-	return d.doLookupHost(ctx, domain)
+	return nx.doLookupHost(ctx, domain)
 }
 
-func (d *Dialer) doLookupHost(ctx context.Context, domain string) ([]string, error) {
+func (nx *Network) doLookupHost(ctx context.Context, domain string) ([]string, error) {
 	// if there is a custom LookupHostFunc, use it
-	if d.LookupHostFunc != nil {
-		return d.LookupHostFunc(ctx, domain)
+	if nx.LookupHostFunc != nil {
+		return nx.LookupHostFunc(ctx, domain)
 	}
 
 	// otherwise fallback to the system resolver
@@ -100,17 +67,17 @@ func (d *Dialer) doLookupHost(ctx context.Context, domain string) ([]string, err
 	return reso.LookupHost(ctx, domain)
 }
 
-func (d *Dialer) dialLog(ctx context.Context, network, address string) (net.Conn, error) {
+func (nx *Network) dialLog(ctx context.Context, network, address string) (net.Conn, error) {
 	// TODO(bassosimone): emit structured logs
-	return d.dialNet(ctx, network, address)
+	return nx.dialNet(ctx, network, address)
 }
 
-func (d *Dialer) dialNet(ctx context.Context, network, address string) (net.Conn, error) {
+func (nx *Network) dialNet(ctx context.Context, network, address string) (net.Conn, error) {
 	// TODO(bassosimone): do we want to automatically wrap the connection?
 
 	// if there's an user provided dialer func, use it
-	if d.DialContextFunc != nil {
-		return d.DialContextFunc(ctx, network, address)
+	if nx.DialContextFunc != nil {
+		return nx.DialContextFunc(ctx, network, address)
 	}
 
 	// otherwise use the net package

--- a/netcore/doc.go
+++ b/netcore/doc.go
@@ -8,9 +8,9 @@ connection events via the [log/slog] package.
 
 # Features
 
-- TCP/UDP dialer compatible with the [*net.Dialer];
+- TCP/UDP [*Network.DialContext] method compatible with [net/http].
 
-- TLS dialer compatible with the [*tls.Dialer].
+- TLS [*Network.DialTLSContext] method compatible with [net/http].
 
 # Design Documents
 

--- a/netcore/integration_test.go
+++ b/netcore/integration_test.go
@@ -15,12 +15,12 @@ func TestDialerIntegration(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
-	dialer := netcore.NewDialer()
+	netx := netcore.NewNetwork()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	conn, err := dialer.DialContext(ctx, "tcp", "example.com:80")
+	conn, err := netx.DialContext(ctx, "tcp", "example.com:80")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,12 +33,12 @@ func TestTLSDialerIntegration(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
-	dialer := netcore.NewTLSDialer()
+	netx := netcore.NewNetwork()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	conn, err := dialer.DialContext(ctx, "tcp", "example.com:443")
+	conn, err := netx.DialTLSContext(ctx, "tcp", "example.com:443")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net"
+)
+
+// Network allows dialing and measuring TCP/UDP/TLS connections.
+//
+// Construct using [NewNetwork].
+//
+// A [*Network] is safe for concurrent use by multiple goroutines as long as
+// you don't modify its fields after construction and the underlying fields you
+// may set (e.g., DialContextFunc) are also safe.
+type Network struct {
+	// DialContextFunc is the optional dialer for creating new
+	// TCP and UDP connections. If this field is nil, the default
+	// dialer from the [net] package will be used.
+	DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+	// Logger is the optional structured logger for emitting
+	// structured diagnostic events. If this field is nil, we
+	// will not be emitting structured logs.
+	Logger *slog.Logger
+
+	// LookupHostFunc is the optional function to resolve a domain
+	// name to IP addresses. If this field is nil, we use the
+	// default [*net.Resolver] from the [net] package.
+	LookupHostFunc func(ctx context.Context, domain string) ([]string, error)
+
+	// TLSConfig is the TLS client config to use. If this field is nil, we
+	// will try to create a suitable config based on the network and address
+	// that are passed to the DialTLSContext method.
+	TLSConfig *tls.Config
+}
+
+// NewNetwork constructs a new [*Network] with default settings.
+func NewNetwork() *Network {
+	return &Network{}
+}
+
+// DefaultNetwork is the default [*Network] used by this package.
+var DefaultNetwork = NewNetwork()

--- a/netcore/tlsdialer.go
+++ b/netcore/tlsdialer.go
@@ -5,63 +5,24 @@ package netcore
 import (
 	"context"
 	"crypto/tls"
-	"log/slog"
 	"net"
 )
 
-// TLSDialer dials TLS connections.
-//
-// Construct using [NewTLSDialer].
-//
-// A [*TLSDialer] is safe for concurrent use by multiple goroutines as long as
-// you don't modify its fields after construction and the underlying fields you
-// may set (e.g., DialContextFunc) are also safe.
-type TLSDialer struct {
-	// Config is the TLS client config to use. If this field is nil, we
-	// will try to create a suitable config based on the network and address
-	// that are passed to the DialContext method.
-	Config *tls.Config
-
-	// DialContextFunc is the optional dialer for creating new TCP and UDP
-	// connections. If this field is nil, we use [DefaultDialer].
-	DialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
-
-	// Logger is the optional structured logger for emitting
-	// structured diagnostic events. If this field is nil, we
-	// will not be emitting structured logs.
-	Logger *slog.Logger
-}
-
-// NewTLSDialer constructs a new [*TLSDialer] with default settings.
-func NewTLSDialer() *TLSDialer {
-	return &TLSDialer{}
-}
-
-// DialContext establishes a new TLS connection.
-func (td *TLSDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	config, err := td.config(network, address)
+// DialTLSContext establishes a new TLS connection.
+func (nx *Network) DialTLSContext(ctx context.Context, network, address string) (net.Conn, error) {
+	config, err := nx.tlsConfig(network, address)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(bassosimone): we should use DialContextFunc instead,
-	// which means we need to manually dial here
-	//
-	// TODO(bassosimone): using DialContextFunc here would lead to
-	// lots of code duplication between this and the other dialer
-	// which would probably be quite bad for maintenance.
-	//
-	// OTOH, if I create a single type named Network (for example)
-	// that does both DialContext and DialTLSContext then I am losing
-	// the loose compatibility with standard library types.
 	child := &tls.Dialer{Config: config}
 
 	return child.DialContext(ctx, network, address)
 }
 
-func (td *TLSDialer) config(network, address string) (*tls.Config, error) {
-	if td.Config != nil {
-		config := td.Config.Clone() // make sure we return a cloned config
+func (nx *Network) tlsConfig(network, address string) (*tls.Config, error) {
+	if nx.TLSConfig != nil {
+		config := nx.TLSConfig.Clone() // make sure we return a cloned config
 		return config, nil
 	}
 	return newTLSConfig(network, address)


### PR DESCRIPTION
This commit takes stock of the fact that having two separate types would complicate sharing code and that, in 2024, TLS is so integral to networking that it *is* part of the basic networking.

As such, we just refactor Dialer and TLSDialer into a single type called Network and name DialTLSContext the TLS dialing func.