### PR TITLE
feat: emit dial events

### DIFF
--- a/netcore/conn.go
+++ b/netcore/conn.go
@@ -1,0 +1,36 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/measurexlite/conn.go
+//
+// Conn wrapper.
+//
+
+package netcore
+
+import "net"
+
+// connLocalAddr is a safe way to get the local address of a connection.
+func connLocalAddr(conn net.Conn) net.Addr {
+	if conn != nil && conn.LocalAddr() != nil {
+		return conn.LocalAddr()
+	}
+	return emptyAddr{}
+}
+
+// connRemoteAddr is a safe way to get the remote address of a connection.
+func connRemoteAddr(conn net.Conn) net.Addr {
+	if conn != nil && conn.RemoteAddr() != nil {
+		return conn.RemoteAddr()
+	}
+	return emptyAddr{}
+}
+
+// emptyAddr is an empty [net.Addr].
+type emptyAddr struct{}
+
+// Network implements [net.Addr].
+func (emptyAddr) Network() string { return "" }
+
+// String implements [net.Addr].
+func (emptyAddr) String() string { return "" }

--- a/netcore/doc.go
+++ b/netcore/doc.go
@@ -12,6 +12,8 @@ connection events via the [log/slog] package.
 
 - TLS [*Network.DialTLSContext] method compatible with [net/http].
 
+- Optional logging for structured diagnostic events through [log/slog].
+
 # Design Documents
 
 This package is experimental and has no design documents for now.

--- a/netcore/integration_test.go
+++ b/netcore/integration_test.go
@@ -4,6 +4,8 @@ package netcore_test
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -15,7 +17,9 @@ func TestDialerIntegration(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
 	netx := netcore.NewNetwork()
+	netx.Logger = logger
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -33,7 +37,9 @@ func TestTLSDialerIntegration(t *testing.T) {
 		t.Skip("skip test in short mode")
 	}
 
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
 	netx := netcore.NewNetwork()
+	netx.Logger = logger
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -45,6 +45,10 @@ type Network struct {
 	// will try to create a suitable config based on the network and address
 	// that are passed to the DialTLSContext method.
 	TLSConfig *tls.Config
+
+	// TimeNow is an optional function that returns the current time.
+	// If this field is nil, the [time.Now] function will be used.
+	TimeNow func() time.Time
 }
 
 // NewNetwork constructs a new [*Network] with default settings.
@@ -57,6 +61,8 @@ var DefaultNetwork = NewNetwork()
 
 // timeNow is a function that returns the current time.
 func (nx *Network) timeNow() time.Time {
-	// TODO(bassosimone): allow to override using a specific function
+	if nx.TimeNow != nil {
+		return nx.TimeNow()
+	}
 	return time.Now()
 }

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -11,6 +11,7 @@ import (
 	"crypto/tls"
 	"log/slog"
 	"net"
+	"time"
 )
 
 // Network allows dialing and measuring TCP/UDP/TLS connections.
@@ -53,3 +54,9 @@ func NewNetwork() *Network {
 
 // DefaultNetwork is the default [*Network] used by this package.
 var DefaultNetwork = NewNetwork()
+
+// timeNow is a function that returns the current time.
+func (nx *Network) timeNow() time.Time {
+	// TODO(bassosimone): allow to override using a specific function
+	return time.Now()
+}


### PR DESCRIPTION
Four events occur when dialing:

- lookupHostStart and lookupHostDone;

- connectStart and connectDone.

For now, let us not worry about remapping errors.