### PR TITLE
feat(netsim): factor packet and related definitions

### DIFF
--- a/netsim/link.go
+++ b/netsim/link.go
@@ -9,19 +9,12 @@ package netsim
 import (
 	"log"
 	"sync"
+
+	"github.com/rbmk-project/x/netsim/packet"
 )
 
 // LinkStack is the [*Stack] as seen by a [*Link].
-type LinkStack interface {
-	// EOF returns a channel that is closed when the stack is done.
-	EOF() <-chan struct{}
-
-	// Input returns a channel to send packets to the stack.
-	Input() chan<- *Packet
-
-	// Output returns a channel to receive packets from the stack.
-	Output() <-chan *Packet
-}
+type LinkStack = packet.NetworkDevice
 
 // Link models a link between two [*Stack] instances.
 //

--- a/netsim/packet.go
+++ b/netsim/packet.go
@@ -1,153 +1,28 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// Packet and related definitions.
+// Aliases for Packet and the related definitions.
 //
 
 package netsim
 
-import (
-	"fmt"
-	"net"
-	"net/netip"
-	"strings"
+import "github.com/rbmk-project/x/netsim/packet"
+
+// Type aliases
+type (
+	Packet     = packet.Packet
+	IPProtocol = packet.IPProtocol
+	TCPFlags   = packet.TCPFlags
 )
 
-// IPProtocol is the protocol number of an IP packet.
-type IPProtocol uint8
-
-// String returns the string representation of the IP protocol.
-func (p IPProtocol) String() string {
-	switch p {
-	case IPProtocolTCP:
-		return "tcp"
-
-	case IPProtocolUDP:
-		return "udp"
-
-	default:
-		return "unknown"
-	}
-}
-
+// Constant aliases
 const (
-	// IPProtocolTCP is the TCP protocol number.
-	IPProtocolTCP = 6
+	IPProtocolTCP = packet.IPProtocolTCP
+	IPProtocolUDP = packet.IPProtocolUDP
 
-	// IPProtocolUDP is the UDP protocol number.
-	IPProtocolUDP = 17
+	TCPFlagFIN = packet.TCPFlagFIN
+	TCPFlagSYN = packet.TCPFlagSYN
+	TCPFlagRST = packet.TCPFlagRST
+	TCPFlagPSH = packet.TCPFlagPSH
+	TCPFlagACK = packet.TCPFlagACK
 )
-
-// TCPFlags is a set of TCP flags.
-type TCPFlags uint8
-
-// String returns the string representation of the TCP flags.
-func (flags TCPFlags) String() string {
-	var builder strings.Builder
-
-	if flags&TCPFlagFIN != 0 {
-		builder.WriteString("F")
-	} else {
-		builder.WriteString(".")
-	}
-
-	if flags&TCPFlagSYN != 0 {
-		builder.WriteString("S")
-	} else {
-		builder.WriteString(".")
-	}
-
-	if flags&TCPFlagRST != 0 {
-		builder.WriteString("R")
-	} else {
-		builder.WriteString(".")
-	}
-
-	if flags&TCPFlagPSH != 0 {
-		builder.WriteString("P")
-	} else {
-		builder.WriteString(".")
-	}
-
-	if flags&TCPFlagACK != 0 {
-		builder.WriteString("A")
-	} else {
-		builder.WriteString(".")
-	}
-
-	return builder.String()
-}
-
-const (
-	// TCPFlagFIN is the FIN flag.
-	TCPFlagFIN = 1
-
-	// TCPFlagSYN is the SYN flag.
-	TCPFlagSYN = 2
-
-	// TCPFlagRST is the RST flag.
-	TCPFlagRST = 4
-
-	// TCPFlagPSH is the PSH flag.
-	TCPFlagPSH = 8
-
-	// TCPFlagACK is the ACK flag.
-	TCPFlagACK = 16
-)
-
-// Packet is a network packet.
-type Packet struct {
-	// SrcAddr is the source address.
-	SrcAddr netip.Addr
-
-	// DstAddr is the destination address.
-	DstAddr netip.Addr
-
-	// IPProtocol is the protocol number.
-	IPProtocol IPProtocol
-
-	// SrcPort is the source port.
-	SrcPort uint16
-
-	// DstPort is the destination port.
-	DstPort uint16
-
-	// TCPFlags is the TCP flags.
-	Flags TCPFlags
-
-	// Payload is the packet payload.
-	Payload []byte
-}
-
-// String returns the string representation of the packet.
-func (p *Packet) String() string {
-	switch p.IPProtocol {
-	case IPProtocolTCP:
-		return p.stringTCP()
-	default:
-		return p.stringOtherwise()
-	}
-}
-
-// stringOtherwise returns the string representation of the packet for non-TCP protocols.
-func (p *Packet) stringOtherwise() string {
-	return fmt.Sprintf(
-		"%s -> %s %s length=%d",
-		net.JoinHostPort(p.SrcAddr.String(), fmt.Sprintf("%d", p.SrcPort)),
-		net.JoinHostPort(p.DstAddr.String(), fmt.Sprintf("%d", p.DstPort)),
-		p.IPProtocol.String(),
-		len(p.Payload),
-	)
-}
-
-// stringTCP returns the string representation of the packet for TCP protocol.
-func (p *Packet) stringTCP() string {
-	return fmt.Sprintf(
-		"%s -> %s %s flags=%s length=%d",
-		net.JoinHostPort(p.SrcAddr.String(), fmt.Sprintf("%d", p.SrcPort)),
-		net.JoinHostPort(p.DstAddr.String(), fmt.Sprintf("%d", p.DstPort)),
-		p.IPProtocol.String(),
-		p.Flags.String(),
-		len(p.Payload),
-	)
-}

--- a/netsim/packet/packet.go
+++ b/netsim/packet/packet.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package packet contains [*Packet] and the related definitions.
+package packet
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// IPProtocol is the protocol number of an IP packet.
+type IPProtocol uint8
+
+// String returns the string representation of the IP protocol.
+func (p IPProtocol) String() string {
+	switch p {
+	case IPProtocolTCP:
+		return "tcp"
+
+	case IPProtocolUDP:
+		return "udp"
+
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// IPProtocolTCP is the TCP protocol number.
+	IPProtocolTCP = 6
+
+	// IPProtocolUDP is the UDP protocol number.
+	IPProtocolUDP = 17
+)
+
+// TCPFlags is a set of TCP flags.
+type TCPFlags uint8
+
+// String returns the string representation of the TCP flags.
+func (flags TCPFlags) String() string {
+	var builder strings.Builder
+
+	if flags&TCPFlagFIN != 0 {
+		builder.WriteString("F")
+	} else {
+		builder.WriteString(".")
+	}
+
+	if flags&TCPFlagSYN != 0 {
+		builder.WriteString("S")
+	} else {
+		builder.WriteString(".")
+	}
+
+	if flags&TCPFlagRST != 0 {
+		builder.WriteString("R")
+	} else {
+		builder.WriteString(".")
+	}
+
+	if flags&TCPFlagPSH != 0 {
+		builder.WriteString("P")
+	} else {
+		builder.WriteString(".")
+	}
+
+	if flags&TCPFlagACK != 0 {
+		builder.WriteString("A")
+	} else {
+		builder.WriteString(".")
+	}
+
+	return builder.String()
+}
+
+const (
+	// TCPFlagFIN is the FIN flag.
+	TCPFlagFIN = 1
+
+	// TCPFlagSYN is the SYN flag.
+	TCPFlagSYN = 2
+
+	// TCPFlagRST is the RST flag.
+	TCPFlagRST = 4
+
+	// TCPFlagPSH is the PSH flag.
+	TCPFlagPSH = 8
+
+	// TCPFlagACK is the ACK flag.
+	TCPFlagACK = 16
+)
+
+// Packet is a network packet.
+type Packet struct {
+	// SrcAddr is the source address.
+	SrcAddr netip.Addr
+
+	// DstAddr is the destination address.
+	DstAddr netip.Addr
+
+	// IPProtocol is the protocol number.
+	IPProtocol IPProtocol
+
+	// SrcPort is the source port.
+	SrcPort uint16
+
+	// DstPort is the destination port.
+	DstPort uint16
+
+	// TCPFlags is the TCP flags.
+	Flags TCPFlags
+
+	// Payload is the packet payload.
+	Payload []byte
+}
+
+// String returns the string representation of the packet.
+func (p *Packet) String() string {
+	switch p.IPProtocol {
+	case IPProtocolTCP:
+		return p.stringTCP()
+	default:
+		return p.stringOtherwise()
+	}
+}
+
+// stringOtherwise returns the string representation of the packet for non-TCP protocols.
+func (p *Packet) stringOtherwise() string {
+	return fmt.Sprintf(
+		"%s -> %s %s length=%d",
+		net.JoinHostPort(p.SrcAddr.String(), fmt.Sprintf("%d", p.SrcPort)),
+		net.JoinHostPort(p.DstAddr.String(), fmt.Sprintf("%d", p.DstPort)),
+		p.IPProtocol.String(),
+		len(p.Payload),
+	)
+}
+
+// stringTCP returns the string representation of the packet for TCP protocol.
+func (p *Packet) stringTCP() string {
+	return fmt.Sprintf(
+		"%s -> %s %s flags=%s length=%d",
+		net.JoinHostPort(p.SrcAddr.String(), fmt.Sprintf("%d", p.SrcPort)),
+		net.JoinHostPort(p.DstAddr.String(), fmt.Sprintf("%d", p.DstPort)),
+		p.IPProtocol.String(),
+		p.Flags.String(),
+		len(p.Payload),
+	)
+}
+
+// NetworkDevice is a network device to read/write [*Packet].
+type NetworkDevice interface {
+	// EOF returns a channel that is closed when the device is closed.
+	EOF() <-chan struct{}
+
+	// Input returns a channel to send [*Packet] to the device.
+	Input() chan<- *Packet
+
+	// Output returns a channel to receive [*Packet] from the device.
+	Output() <-chan *Packet
+}


### PR DESCRIPTION
I want to add more packages for additional functionality like delays, packet filtering, etc. The first step is to ensure the definition of packet and related definitions, e.g., NetworkDevice are shared, so other packages can use them.