### PR TITLE
feat(netsim): allow multiple IP addrs per stack

### DIFF
--- a/netsim/errno_unix.go
+++ b/netsim/errno_unix.go
@@ -11,6 +11,9 @@ package netsim
 import "golang.org/x/sys/unix"
 
 const (
+	// EADDRNOTAVAIL is the address not available error.
+	EADDRNOTAVAIL = unix.EADDRNOTAVAIL
+
 	// EADDRINUSE is the address in use error.
 	EADDRINUSE = unix.EADDRINUSE
 

--- a/netsim/errno_windows.go
+++ b/netsim/errno_windows.go
@@ -11,6 +11,9 @@ package netsim
 import "golang.org/x/sys/windows"
 
 const (
+	// EADDRNOTAVAIL is the address not available error.
+	EADDRNOTAVAIL = windows.WSAEADDRNOTAVAIL
+
 	// EADDRINUSE is the address in use error.
 	EADDRINUSE = windows.WSAEADDRINUSE
 

--- a/netsim/packet/packet.go
+++ b/netsim/packet/packet.go
@@ -151,6 +151,9 @@ func (p *Packet) stringTCP() string {
 
 // NetworkDevice is a network device to read/write [*Packet].
 type NetworkDevice interface {
+	// Addresses returns the device addresses.
+	Addresses() []netip.Addr
+
 	// EOF returns a channel that is closed when the device is closed.
 	EOF() <-chan struct{}
 

--- a/netsim/stack.go
+++ b/netsim/stack.go
@@ -90,7 +90,7 @@ func (ns *Stack) demuxLoop() {
 //
 // The algorithm is as follows:
 //
-// 1. first try using the five tuple.
+// 1. first, try using the five tuple.
 //
 // 2. if not found, try using the three tuple, where
 // the remote address is invalid.
@@ -303,7 +303,7 @@ func (ns *Stack) dial(protocol IPProtocol, address string) (*Port, error) {
 	// Pick the correct local address for the remote address.
 	var ipAddrLocal netip.Addr
 	for _, addr := range ns.addrs {
-		if raddr.Addr().Is4() == addr.Is4() {
+		if raddr.Addr().Is4() && addr.Is4() {
 			ipAddrLocal = addr
 			break
 		}

--- a/netsim/tcplistener.go
+++ b/netsim/tcplistener.go
@@ -45,8 +45,9 @@ func (tl *TCPListener) Accept() (net.Conn, error) {
 		if pkt.Flags != TCPFlagSYN {
 			continue
 		}
+		laddr := netip.AddrPortFrom(pkt.DstAddr, pkt.DstPort)
 		raddr := netip.AddrPortFrom(pkt.SrcAddr, pkt.SrcPort)
-		conn, err := tl.stack.NewTCPConn(tl.Port.addr.LocalAddr, raddr)
+		conn, err := tl.stack.NewTCPConn(laddr, raddr)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
This change ensures one can configure multiple IP addrs for a given network stack. In turn, this opens up the possibility of having IPv4 and IPv6 addresses for a stack.