### PR TITLE
refactor(netsim): move most code inside netsim/netstack

### DIFF
--- a/netsim/aliases.go
+++ b/netsim/aliases.go
@@ -1,0 +1,24 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Aliases
+//
+
+package netsim
+
+import (
+	"github.com/rbmk-project/x/netsim/link"
+	"github.com/rbmk-project/x/netsim/netstack"
+)
+
+// Stack is an alias for [netstack.Stack].
+type Stack = netstack.Stack
+
+// Link is an alias for [link.Link].
+type Link = link.Link
+
+// NewStack is an alias for [netstack.New].
+var NewStack = netstack.New
+
+// NewLink is an alias for [link.New].
+var NewLink = link.New

--- a/netsim/link/link.go
+++ b/netsim/link/link.go
@@ -1,10 +1,7 @@
-//
 // SPDX-License-Identifier: GPL-3.0-or-later
-//
-// Packet and related definitions.
-//
 
-package netsim
+// Package link models a point-to-point network link.
+package link
 
 import (
 	"sync"
@@ -15,9 +12,12 @@ import (
 // LinkStack is the [*Stack] as seen by a [*Link].
 type LinkStack = packet.NetworkDevice
 
+// Packet is the [packet.Packet] alias used by this package.
+type Packet = packet.Packet
+
 // Link models a link between two [*Stack] instances.
 //
-// The zero value is not ready to use; construct using [NewLink].
+// The zero value is not ready to use; construct using [New].
 type Link struct {
 	// eof unblocks any blocking channel operation.
 	eof chan struct{}
@@ -26,10 +26,10 @@ type Link struct {
 	eofOnce sync.Once
 }
 
-// NewLink creates a new [*Link] using two [*Stack] and
+// New creates a new [*Link] using two [*Stack] and
 // sets up moving packets between the two stacks. Use Close
 // to shut down background goroutines.
-func NewLink(left, right LinkStack) *Link {
+func New(left, right LinkStack) *Link {
 	lnk := &Link{
 		eof:     make(chan struct{}),
 		eofOnce: sync.Once{},

--- a/netsim/netstack/addr.go
+++ b/netsim/netstack/addr.go
@@ -4,7 +4,7 @@
 // net.Addr implementation.
 //
 
-package netsim
+package netstack
 
 import (
 	"net"

--- a/netsim/netstack/deadline.go
+++ b/netsim/netstack/deadline.go
@@ -6,7 +6,7 @@
 // Deadline management.
 //
 
-package netsim
+package netstack
 
 import (
 	"sync"

--- a/netsim/netstack/dialer.go
+++ b/netsim/netstack/dialer.go
@@ -4,7 +4,7 @@
 // Dialer implementation
 //
 
-package netsim
+package netstack
 
 import (
 	"context"

--- a/netsim/netstack/errno_unix.go
+++ b/netsim/netstack/errno_unix.go
@@ -6,7 +6,7 @@
 // UNIX errno definitions.
 //
 
-package netsim
+package netstack
 
 import "golang.org/x/sys/unix"
 

--- a/netsim/netstack/errno_windows.go
+++ b/netsim/netstack/errno_windows.go
@@ -6,7 +6,7 @@
 // Windows errno definitions.
 //
 
-package netsim
+package netstack
 
 import "golang.org/x/sys/windows"
 

--- a/netsim/netstack/packet.go
+++ b/netsim/netstack/packet.go
@@ -4,7 +4,7 @@
 // Aliases for Packet and the related definitions.
 //
 
-package netsim
+package netstack
 
 import "github.com/rbmk-project/x/netsim/packet"
 

--- a/netsim/netstack/port.go
+++ b/netsim/netstack/port.go
@@ -4,7 +4,7 @@
 // TCP/UDP port implementation.
 //
 
-package netsim
+package netstack
 
 import (
 	"fmt"

--- a/netsim/netstack/stack.go
+++ b/netsim/netstack/stack.go
@@ -4,7 +4,7 @@
 // Network stack
 //
 
-package netsim
+package netstack
 
 import (
 	"context"
@@ -49,10 +49,10 @@ type Stack struct {
 	ports map[PortAddr]*Port
 }
 
-// NewStack creates a new [*Stack] instance and starts a
+// New creates a new [*Stack] instance and starts a
 // goroutine demuxing incoming traffic. Remember to invoke
 // Close to stop any muxing/demuxing goroutine.
-func NewStack(addrs ...netip.Addr) *Stack {
+func New(addrs ...netip.Addr) *Stack {
 	const (
 		// firstEphemeralPort is the first ephemeral port
 		// to use according to RFC6335.

--- a/netsim/netstack/tcpconn.go
+++ b/netsim/netstack/tcpconn.go
@@ -4,7 +4,7 @@
 // TCP Conn/PacketConn.
 //
 
-package netsim
+package netstack
 
 import (
 	"bytes"

--- a/netsim/netstack/tcplistener.go
+++ b/netsim/netstack/tcplistener.go
@@ -4,7 +4,7 @@
 // TCP Listener/PacketListener.
 //
 
-package netsim
+package netstack
 
 import (
 	"net"

--- a/netsim/netstack/udpconn.go
+++ b/netsim/netstack/udpconn.go
@@ -4,7 +4,7 @@
 // UDP Conn/PacketConn.
 //
 
-package netsim
+package netstack
 
 import "net"
 


### PR DESCRIPTION
The top-level package should contain more specific code handling scenarios rather than the netstack stub network.

Let's make this possibly by moving the netstack into its own package.