### PR TITLE
fix(netstack): repair reply from listening UDP socket

### DIFF
--- a/netsim/netstack/port.go
+++ b/netsim/netstack/port.go
@@ -221,7 +221,7 @@ func (gp *Port) WritePacket(payload []byte, flags TCPFlags, raddr netip.AddrPort
 		}
 	}
 
-	// Make sure the local addres is specified
+	// Make sure the local address is specified
 	laddr := gp.addr.LocalAddr
 	if laddr.Addr().IsUnspecified() {
 		ipAddr, err := gp.stack.FindLocalAddrFor(raddr.Addr())

--- a/netsim/netstack/stack.go
+++ b/netsim/netstack/stack.go
@@ -380,14 +380,14 @@ func (ns *Stack) dial(protocol IPProtocol, address string) (*Port, error) {
 // FindLocalAddrFor returns the first local address that has
 // the same IP version as the remote address.
 func (ns *Stack) FindLocalAddrFor(raddr netip.Addr) (netip.Addr, error) {
-	// Normalized to IPv4 if mapped.
+	// Normalize to IPv4 if mapped.
 	if raddr.Is4In6() {
 		raddr = raddr.Unmap()
 	}
 
 	var result netip.Addr
 	for _, addr := range ns.addrs {
-		// Normalized to IPv4 if mapped.
+		// Normalize to IPv4 if mapped.
 		if addr.Is4In6() {
 			addr = addr.Unmap()
 		}

--- a/netsim/netstack/stack.go
+++ b/netsim/netstack/stack.go
@@ -361,17 +361,9 @@ func (ns *Stack) dial(protocol IPProtocol, address string) (*Port, error) {
 	}
 
 	// Pick the correct local address for the remote address.
-	var ipAddrLocal netip.Addr
-	for _, addr := range ns.addrs {
-		if raddr.Addr().Is4() && addr.Is4() {
-			ipAddrLocal = addr
-			break
-		}
-		ipAddrLocal = addr
-		break
-	}
-	if !ipAddrLocal.IsValid() {
-		return nil, EADDRNOTAVAIL
+	ipAddrLocal, err := ns.FindLocalAddrFor(raddr.Addr())
+	if err != nil {
+		return nil, err
 	}
 
 	// Construct the local address and use a local port.
@@ -383,6 +375,39 @@ func (ns *Stack) dial(protocol IPProtocol, address string) (*Port, error) {
 
 	// Create the port proper and setup muxing traffic.
 	return ns.newPortLocked(protocol, laddr, raddr)
+}
+
+// FindLocalAddrFor returns the first local address that has
+// the same IP version as the remote address.
+func (ns *Stack) FindLocalAddrFor(raddr netip.Addr) (netip.Addr, error) {
+	// Normalized to IPv4 if mapped.
+	if raddr.Is4In6() {
+		raddr = raddr.Unmap()
+	}
+
+	var result netip.Addr
+	for _, addr := range ns.addrs {
+		// Normalized to IPv4 if mapped.
+		if addr.Is4In6() {
+			addr = addr.Unmap()
+		}
+
+		// Check for exact match with address family
+		if raddr.Is4() && addr.Is4() {
+			result = addr
+			break
+		}
+		if raddr.Is6() && addr.Is6() {
+			result = addr
+			break
+		}
+	}
+
+	// Produce the final result.
+	if !result.IsValid() {
+		return netip.Addr{}, EADDRNOTAVAIL
+	}
+	return result, nil
 }
 
 // newEphemeralPortNumberLocked opens a new local port, if possible, or returns an error.


### PR DESCRIPTION
To this end, we need to handle the case where we're sending and the source address is unspecified, by finding the proper source address for the destination address.

While there, significantly fix how we determine the proper source address by precisely mapping the address family, and by adding support for IPv4-mapped IPv6 addresses.