### PR TITLE
feat(netsim): introduce well-known hosts

### DIFF
--- a/netsim/example_dns_test.go
+++ b/netsim/example_dns_test.go
@@ -20,7 +20,7 @@ func Example_dnsOverUDP() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack running a DNS-over-UDP server.
+	// Create server stack emulating dns.google.
 	//
 	// This includes:
 	//
@@ -29,16 +29,10 @@ func Example_dnsOverUDP() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames:       []string{"dns.google"},
-		Addresses:         []string{"8.8.8.8"},
-		DNSOverUDPHandler: scenario.DNSHandler(),
-	}))
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
 
 	// Create and attach the client stack.
-	clientStack := scenario.MustNewStack(&netsim.StackConfig{
-		Addresses: []string{"130.192.91.211"},
-	})
+	clientStack := scenario.MustNewClientStack()
 	scenario.Attach(clientStack)
 
 	// Create a context with a watchdog timeout.

--- a/netsim/example_http_test.go
+++ b/netsim/example_http_test.go
@@ -19,7 +19,7 @@ func Example_http() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack running a HTTP-over-TCP server.
+	// Create server stack emulating dns.google.
 	//
 	// This includes:
 	//
@@ -28,18 +28,10 @@ func Example_http() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames: []string{"dns.google"},
-		Addresses:   []string{"8.8.8.8"},
-		HTTPHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.Write([]byte("Bonsoir, Elliot!\n"))
-		}),
-	}))
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
 
 	// Create and attach the client stack.
-	clientStack := scenario.MustNewStack(&netsim.StackConfig{
-		Addresses: []string{"130.192.91.211"},
-	})
+	clientStack := scenario.MustNewClientStack()
 	scenario.Attach(clientStack)
 
 	// Create the HTTP client
@@ -65,5 +57,5 @@ func Example_http() {
 	fmt.Printf("%s", string(body))
 
 	// Output:
-	// Bonsoir, Elliot!
+	// Google Public DNS server.
 }

--- a/netsim/example_https_test.go
+++ b/netsim/example_https_test.go
@@ -19,7 +19,7 @@ func Example_https() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack running a HTTP-over-TLS server.
+	// Create server stack emulating dns.google.
 	//
 	// This includes:
 	//
@@ -28,18 +28,10 @@ func Example_https() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames: []string{"dns.google"},
-		Addresses:   []string{"8.8.8.8"},
-		HTTPSHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.Write([]byte("Bonsoir, Elliot!\n"))
-		}),
-	}))
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
 
 	// Create and attach the client stack.
-	clientStack := scenario.MustNewStack(&netsim.StackConfig{
-		Addresses: []string{"130.192.91.211"},
-	})
+	clientStack := scenario.MustNewClientStack()
 	scenario.Attach(clientStack)
 
 	// Create the HTTP client
@@ -65,5 +57,5 @@ func Example_https() {
 	fmt.Printf("%s", string(body))
 
 	// Output:
-	// Bonsoir, Elliot!
+	// Google Public DNS server.
 }

--- a/netsim/example_router_test.go
+++ b/netsim/example_router_test.go
@@ -19,7 +19,7 @@ func Example_router() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack running a DNS server.
+	// Create server stack emulating dns.google.
 	//
 	// This includes:
 	//
@@ -28,30 +28,13 @@ func Example_router() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames:       []string{"dns.google"},
-		Addresses:         []string{"8.8.8.8"},
-		DNSOverUDPHandler: scenario.DNSHandler(),
-		HTTPSHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.Write([]byte("Bonsoir, Elliot!\n"))
-		}),
-	}))
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
 
-	// Create server stack running a HTTP-over-TLS server.
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames:       []string{"www.example.com"},
-		Addresses:         []string{"93.184.215.14"},
-		DNSOverUDPHandler: scenario.DNSHandler(),
-		HTTPSHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.Write([]byte("Bonsoir, Elliot!\n"))
-		}),
-	}))
+	// Create server stack emulating www.example.com.
+	scenario.Attach(scenario.MustNewExampleComStack())
 
 	// Create and attach the client stack.
-	clientStack := scenario.MustNewStack(&netsim.StackConfig{
-		Addresses:       []string{"130.192.91.211"},
-		ClientResolvers: []string{"8.8.8.8"},
-	})
+	clientStack := scenario.MustNewClientStack()
 	scenario.Attach(clientStack)
 
 	// Create the HTTP client
@@ -77,5 +60,5 @@ func Example_router() {
 	fmt.Printf("%s", string(body))
 
 	// Output:
-	// Bonsoir, Elliot!
+	// Example Web Server.
 }

--- a/netsim/example_tls_test.go
+++ b/netsim/example_tls_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/rbmk-project/x/netsim"
@@ -21,7 +20,7 @@ func Example_tls() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack running a HTTP-over-TLS server.
+	// Create server stack emulating dns.google.
 	//
 	// This includes:
 	//
@@ -30,18 +29,10 @@ func Example_tls() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewStack(&netsim.StackConfig{
-		DomainNames: []string{"dns.google"},
-		Addresses:   []string{"8.8.8.8"},
-		HTTPSHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			rw.Write([]byte("Bonsoir, Elliot!\n"))
-		}),
-	}))
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
 
 	// Create and attach the client stack.
-	clientStack := scenario.MustNewStack(&netsim.StackConfig{
-		Addresses: []string{"130.192.91.211"},
-	})
+	clientStack := scenario.MustNewClientStack()
 	scenario.Attach(clientStack)
 
 	// Create a context with a watchdog timeout.

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -1,0 +1,73 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Well-known host configurations for common internet services
+// used in network testing scenarios.
+//
+
+package netsim
+
+import "net/http"
+
+// MustNewGoogleDNSStack creates a new stack simulating dns.google.
+func (s *Scenario) MustNewGoogleDNSStack() *Stack {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Google Public DNS server.\n"))
+	})
+	return s.MustNewStack(&StackConfig{
+		DomainNames: []string{
+			"dns.google",
+			"dns.google.com",
+		},
+		Addresses: []string{
+			"2001:4860:4860::8888",
+			"8.8.8.8",
+		},
+		DNSOverUDPHandler: s.DNSHandler(),
+		HTTPHandler:       handler,
+		HTTPSHandler:      handler,
+	})
+}
+
+// MustNewExampleComStack creates a new stack simulating www.example.com.
+func (s *Scenario) MustNewExampleComStack() *Stack {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Example Web Server.\n"))
+	})
+	return s.MustNewStack(&StackConfig{
+		DomainNames: []string{
+			"www.example.com",
+			"example.com",
+			"www.example.org",
+			"example.org",
+		},
+		Addresses: []string{
+			"2606:2800:21f:cb07:6820:80da:af6b:8b2c",
+			"93.184.216.34",
+		},
+		HTTPHandler:  handler,
+		HTTPSHandler: handler,
+	})
+}
+
+// MustNewClientStack creates a new client stack with standard testing configuration.
+//
+// We use GARR's (Italian Research & Education Network) public addresses
+// (193.206.158.22 and 2001:760:0:158::22) as default client addresses.
+// These are chosen over documentation ranges (like 192.0.2.0/24) to avoid
+// triggering bogon filters in network simulation scenarios, while still
+// being associated with a public research institution.
+//
+// The stack uses Google's public DNS addresses as the default resolvers.
+func (s *Scenario) MustNewClientStack() *Stack {
+	return s.MustNewStack(&StackConfig{
+		Addresses: []string{
+			"193.206.158.22",
+			"2001:760:0:158::22",
+		},
+		ClientResolvers: []string{
+			"2001:4860:4860::8888",
+			"8.8.8.8",
+		},
+	})
+}


### PR DESCRIPTION
This allows us to further reduce the boilerplate in tests.