### PR TITLE
feat: add packet filtering support

### DIFF
--- a/netsim/packet/packet.go
+++ b/netsim/packet/packet.go
@@ -182,3 +182,34 @@ func NewNetworkDeviceIOChannels() (chan *Packet, chan *Packet) {
 	output := make(chan *Packet, DefaultBufferChannel)
 	return input, output
 }
+
+// Target represents what to do with a [*Packet]
+// similarly to `iptables` target.
+type Target int
+
+const (
+	// ACCEPT lets the [*Packet] continue through the chain.
+	ACCEPT Target = iota
+
+	// DROP silently discards the [*Packet].
+	DROP
+)
+
+// Filter processes [*Packet] and determines its fate.
+//
+// The Filter method returns the [Target] and optionally
+// a list of new packets to inject.
+type Filter interface {
+	Filter(pkt *Packet) (Target, []*Packet)
+}
+
+// FilterFunc allows using a function as a [Filter].
+type FilterFunc func(pkt *Packet) (Target, []*Packet)
+
+// Ensure [FilterFunc] implements the [Filter] interface.
+var _ Filter = FilterFunc(nil)
+
+// Filter implements the [Filter] interface.
+func (fx FilterFunc) Filter(p *Packet) (Target, []*Packet) {
+	return fx(p)
+}


### PR DESCRIPTION
This commit adds support for filtering packets in the router.

The interfaces for filtering packets go into `packet/packet.go` since they are integral to our network simulation.

We implementing filtering in the router because we need the ability to inject arbitrary packets in all directions. It won't be possible to implement filtering with links, since they are unidirectional (i.e., one direction of a given link does not have access to the link direction).