### PR TITLE
feat(netsim): implement DNS poisoning

### DIFF
--- a/netsim/censor/dns.go
+++ b/netsim/censor/dns.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package censor
+
+import (
+	"github.com/miekg/dns"
+	netsimdns "github.com/rbmk-project/x/netsim/dns"
+	"github.com/rbmk-project/x/netsim/packet"
+)
+
+// Database is an alias for [netsimdns.Database].
+type Database = netsimdns.Database
+
+// DNSPoisoner implements GFW-style DNS poisoning
+type DNSPoisoner struct {
+	db *Database
+}
+
+// NewDNSPoisoner creates a new DNS poisoner that injects
+// responses as configured in the given database.
+func NewDNSPoisoner(db *Database) *DNSPoisoner {
+	return &DNSPoisoner{db: db}
+}
+
+// Filter implements [packet.Filter].
+func (p *DNSPoisoner) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet) {
+	// Only process UDP DNS queries
+	if pkt.IPProtocol != packet.IPProtocolUDP || pkt.DstPort != 53 {
+		return packet.ACCEPT, nil
+	}
+
+	// Parse DNS query
+	query := new(dns.Msg)
+	if err := query.Unpack(pkt.Payload); err != nil {
+		return packet.ACCEPT, nil
+	}
+
+	// Only process queries
+	if query.Response || len(query.Question) != 1 {
+		return packet.ACCEPT, nil
+	}
+
+	// Create poisoned response
+	spoofed := p.spoof(pkt, query)
+
+	// Let original query continue
+	return packet.ACCEPT, spoofed
+}
+
+func (p *DNSPoisoner) spoof(
+	pkt *packet.Packet, query *dns.Msg) []*packet.Packet {
+	// Prepare the response
+	resp := &dns.Msg{}
+	resp.SetReply(query)
+
+	// Get records from database
+	q0 := query.Question[0]
+	rrs, found := p.db.Lookup(q0.Qtype, q0.Name)
+	if !found {
+		return []*packet.Packet{}
+	}
+	resp.Answer = rrs
+
+	// Pack the response
+	payload, err := resp.Pack()
+	if err != nil {
+		return []*packet.Packet{}
+	}
+
+	// Create the spoofed packet
+	return []*packet.Packet{{
+		TTL:        64,
+		SrcAddr:    pkt.DstAddr,
+		DstAddr:    pkt.SrcAddr,
+		IPProtocol: packet.IPProtocolUDP,
+		SrcPort:    pkt.DstPort,
+		DstPort:    pkt.SrcPort,
+		Payload:    payload,
+	}}
+}

--- a/netsim/dns/dns.go
+++ b/netsim/dns/dns.go
@@ -117,7 +117,7 @@ func (dd *Database) Handle(rw dnscoretest.ResponseWriter, rawQuery []byte) {
 		q0.Qtype == dns.TypeAAAA ||
 		q0.Qtype == dns.TypeCNAME:
 		var found bool
-		response.Answer, found = dd.lookup(q0.Qtype, name)
+		response.Answer, found = dd.Lookup(q0.Qtype, name)
 		if !found {
 			response.Rcode = dns.RcodeNameError
 		}
@@ -133,11 +133,11 @@ func (dd *Database) Handle(rw dnscoretest.ResponseWriter, rawQuery []byte) {
 	rw.Write(rawResp)
 }
 
-// lookup returns the DNS records for a domain name.
+// Lookup returns the DNS records for a domain name.
 //
 // This method is goroutine safe as long as one does not
 // modify the database while handling queries.
-func (dd *Database) lookup(qtype uint16, name string) ([]dns.RR, bool) {
+func (dd *Database) Lookup(qtype uint16, name string) ([]dns.RR, bool) {
 	const maxloops = 10
 	var rrs []dns.RR
 	for idx := 0; idx < maxloops; idx++ {

--- a/netsim/example_censor_dns_test.go
+++ b/netsim/example_censor_dns_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netsim_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/rbmk-project/dnscore"
+	"github.com/rbmk-project/x/netsim"
+	"github.com/rbmk-project/x/netsim/censor"
+	netsimdns "github.com/rbmk-project/x/netsim/dns"
+)
+
+// This example shows how to use [netsim] to simulate GFW-style DNS
+// censorship, where poisoned responses are injected before the legitimate
+// response arrives. The example demonstrates:
+//
+// 1. how to configure DNS poisoning using a database
+// 2. how to collect multiple DNS responses using dnscore
+// 3. the expected order of responses (poisoned then legitimate)
+//
+// This example DOES NOT show how to validate responses using [dnscore]
+// since that is outside its specific scope.
+func Example_censorDNS() {
+	// Create a new scenario using the given directory to cache
+	// the certificates used by the simulated PKI
+	scenario := netsim.NewScenario("testdata")
+	defer scenario.Close()
+
+	// Create server stack emulating dns.google (8.8.8.8).
+	//
+	// This includes:
+	//
+	// 1. creating, attaching, and enabling routing for a server stack
+	//
+	// 2. registering the proper domain names and addresses
+	//
+	// 3. updating the PKI database to include the server's certificate
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
+
+	// Configure DNS poisoning happening on the scenario router
+	// thus modeling the typical behaviour of the GFW.
+	censorDB := netsimdns.NewDatabase()
+	censorDB.AddAddresses([]string{"dns.google"}, []string{"10.0.0.1"})
+	scenario.Router().AddFilter(censor.NewDNSPoisoner(censorDB))
+
+	// Create and attach the client stack.
+	clientStack := scenario.MustNewClientStack()
+	scenario.Attach(clientStack)
+
+	// Create a context with a watchdog timeout.
+	//
+	// In real measurements this would typically be controlled by
+	// --wait-duplicates or natural timing of other operations like
+	// TCP/TLS handshakes and fetching related web pages.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create DNS query for dns.google A record
+	query, err := dnscore.NewQuery("dns.google.", dns.TypeA)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Configure transport to use our simulated network
+	txp := dnscore.NewTransport()
+	txp.DialContext = clientStack.DialContext
+
+	// Query 8.8.8.8 over UDP and collect responses
+	serverAddr := &dnscore.ServerAddr{
+		Protocol: dnscore.ProtocolUDP,
+		Address:  "8.8.8.8:53",
+	}
+	results := txp.QueryWithDuplicates(ctx, serverAddr, query)
+
+	// Print responses as they arrive.
+	//
+	// We expect:
+	//
+	// 1. poisoned response (10.0.0.1) from router
+	//
+	// 2. legitimate response (8.8.8.8) from server
+	//
+	// After two responses, we cancel the context. In production,
+	// we will stop after a timeout or perform other operations and
+	// then check whether there are more addresses to measure.
+	var count int
+	for result := range results {
+		if err := result.Err; err != nil {
+			log.Fatal(err)
+		}
+		for _, ans := range result.Msg.Answer {
+			if a, ok := ans.(*dns.A); ok {
+				fmt.Printf("%s\n", a.A.String())
+			}
+		}
+		count++
+		if count >= 2 {
+			cancel()
+		}
+	}
+
+	// Output:
+	// 10.0.0.1
+	// 8.8.8.8
+}

--- a/netsim/example_censor_dns_test.go
+++ b/netsim/example_censor_dns_test.go
@@ -91,7 +91,10 @@ func Example_censorDNS() {
 	var count int
 	for result := range results {
 		if err := result.Err; err != nil {
-			log.Fatal(err)
+			// Errors here typically are caused by us closing
+			// the connection and, anyway, for this test we only
+			// care about seeing the duplicate responses.
+			break
 		}
 		for _, ans := range result.Msg.Answer {
 			if a, ok := ans.(*dns.A); ok {

--- a/netsim/scenario.go
+++ b/netsim/scenario.go
@@ -46,6 +46,11 @@ func NewScenario(cacheDir string) *Scenario {
 	}
 }
 
+// Router returns the [*router.Router] for the scenario.
+func (s *Scenario) Router() *router.Router {
+	return s.router
+}
+
 // DNSHandler returns the [DNSHandler] for the scenario. The returned
 // handler will serve queries based on the scenario's DNS database.
 func (s *Scenario) DNSHandler() DNSHandler {


### PR DESCRIPTION
We're aiming to do something similar to the GFW. We will be able to write good integration tests for `rbmk` using this code.