### PR TITLE
BREAKING CHANGE: remove NewNetwork constructor

### DIFF
--- a/netcore/integration_test.go
+++ b/netcore/integration_test.go
@@ -18,7 +18,7 @@ func TestDialerIntegration(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
-	netx := netcore.NewNetwork()
+	netx := &netcore.Network{}
 	netx.Logger = logger
 	netx.WrapConn = netcore.WrapConn
 
@@ -39,7 +39,7 @@ func TestTLSDialerIntegration(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
-	netx := netcore.NewNetwork()
+	netx := &netcore.Network{}
 	netx.Logger = logger
 	netx.WrapConn = netcore.WrapConn
 

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -16,7 +16,7 @@ import (
 
 // Network allows dialing and measuring TCP/UDP/TLS connections.
 //
-// Construct using [NewNetwork].
+// The zero value is ready to use.
 //
 // A [*Network] is safe for concurrent use by multiple goroutines as long as
 // you don't modify its fields after construction and the underlying fields you
@@ -55,13 +55,8 @@ type Network struct {
 	WrapConn func(ctx context.Context, netx *Network, conn net.Conn) net.Conn
 }
 
-// NewNetwork constructs a new [*Network] with default settings.
-func NewNetwork() *Network {
-	return &Network{}
-}
-
 // DefaultNetwork is the default [*Network] used by this package.
-var DefaultNetwork = NewNetwork()
+var DefaultNetwork = &Network{}
 
 // timeNow is a function that returns the current time.
 func (nx *Network) timeNow() time.Time {

--- a/netsim/netstack/dialer.go
+++ b/netsim/netstack/dialer.go
@@ -35,7 +35,7 @@ func (ns *Stack) DialContext(ctx context.Context, network, address string) (net.
 	}
 
 	// Configure dnscore and netcore to perform the actual dial.
-	netx := netcore.NewNetwork()
+	netx := &netcore.Network{}
 	netx.DialContextFunc = ns.dialContext
 	reso := &dnscore.Resolver{}
 	reso.Config = dnscore.NewConfig()


### PR DESCRIPTION
The constructor was just creating the zero value. So remove unneeded complexity and just tell people to construct and use a zero value instead. In other words:

- replace `NewNetwork()` with `&Network{}`.