### PR TITLE
feat(netsim/censor): implement TCP resetter

### DIFF
--- a/netsim/censor/tcp.go
+++ b/netsim/censor/tcp.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package censor
+
+import (
+	"bytes"
+	"net/netip"
+
+	"github.com/rbmk-project/x/netsim/packet"
+)
+
+// TCPResetter implements RST-based TCP connection interruption.
+//
+// When configured with a pattern, it only injects RST segments
+// for packets containing that pattern, while allowing empty
+// packets (e.g., SYN) to pass through. This enables pattern matching
+// on protocol-specific content (e.g., TLS SNI) while allowing
+// the TCP handshake to complete normally.
+type TCPResetter struct {
+	// target specifies an optional specific endpoint to filter;
+	// if zero, applies to all TCP connections.
+	target netip.AddrPort
+
+	// pattern is an optional byte pattern to match in payload;
+	// if nil, only considers the target (if set).
+	pattern []byte
+}
+
+// NewTCPResetter creates a new [*TCPResetter].
+//
+// If target is zero, it applies to all TCP connections.
+//
+// If pattern is zero-length, it doesn't perform payload matching.
+//
+// When pattern is set, empty packets are allowed through
+// to permit TCP handshakes to complete.
+func NewTCPResetter(target netip.AddrPort, pattern []byte) *TCPResetter {
+	return &TCPResetter{target: target, pattern: pattern}
+}
+
+// Filter implements [packet.Filter].
+func (r *TCPResetter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet) {
+	// Only process TCP packets
+	if pkt.IPProtocol != packet.IPProtocolTCP {
+		return packet.ACCEPT, nil
+	}
+
+	// Check if we need to filter a specific endpoint
+	if r.target.IsValid() {
+		if pkt.DstAddr != r.target.Addr() || pkt.DstPort != r.target.Port() {
+			return packet.ACCEPT, nil
+		}
+	}
+
+	// If we have a pattern, check the payload. Note: we explicitly
+	// accept packets with empty payload (e.g., SYN) to allow the TCP
+	// handshake to complete before potentially injecting RST.
+	if r.pattern != nil {
+		if len(pkt.Payload) <= 0 || !bytes.Contains(pkt.Payload, r.pattern) {
+			return packet.ACCEPT, nil
+		}
+	}
+
+	// Create RST packet
+	rst := &packet.Packet{
+		TTL:        64,
+		SrcAddr:    pkt.DstAddr,
+		DstAddr:    pkt.SrcAddr,
+		IPProtocol: packet.IPProtocolTCP,
+		SrcPort:    pkt.DstPort,
+		DstPort:    pkt.SrcPort,
+		Flags:      packet.TCPFlagRST,
+	}
+
+	return packet.ACCEPT, []*packet.Packet{rst}
+}

--- a/netsim/example_censor_tls_test.go
+++ b/netsim/example_censor_tls_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netsim_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/netip"
+
+	"github.com/rbmk-project/x/netsim"
+	"github.com/rbmk-project/x/netsim/censor"
+)
+
+// This example shows how to use [netsim] to simulate
+// SNI-based TLS blocking using RST injection.
+func Example_tlsRSTInjection() {
+	// Create a new scenario using the given directory to cache
+	// the certificates used by the simulated PKI
+	scenario := netsim.NewScenario("testdata")
+	defer scenario.Close()
+
+	// Create server stack emulating dns.google.
+	//
+	// This includes:
+	//
+	// 1. creating, attaching, and enabling routing for a server stack
+	//
+	// 2. registering the proper domain names and addresses
+	//
+	// 3. updating the PKI database to include the server's certificate
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
+
+	// Configure RST injection on the scenario router targeting
+	// connections where the SNI matches "dns.google"
+	scenario.Router().AddFilter(censor.NewTCPResetter(
+		netip.AddrPort{},     // match any endpoint
+		[]byte("dns.google"), // match SNI
+	))
+
+	// Create and attach the client stack.
+	clientStack := scenario.MustNewClientStack()
+	scenario.Attach(clientStack)
+
+	// Create the HTTP client
+	clientTxp := scenario.NewHTTPTransport(clientStack)
+	defer clientTxp.CloseIdleConnections()
+	clientHTTP := &http.Client{Transport: clientTxp}
+
+	// Attempt the HTTPS request, which should fail due to RST
+	_, err := clientHTTP.Get("https://dns.google/")
+	fmt.Printf("err: %v\n", err)
+
+	// Output:
+	// err: Get "https://dns.google/": connection reset by peer
+}


### PR DESCRIPTION
With this building block we model interference with the TCP and TLS handshakes, using both a pattern and the destination endpoint as possible triggers.