### PR TITLE
feat(netsim/censor): implement DNAT censorship

### DIFF
--- a/netsim/censor/ip.go
+++ b/netsim/censor/ip.go
@@ -4,7 +4,6 @@ package censor
 
 import (
 	"bytes"
-	"fmt"
 	"net/netip"
 	"sync"
 	"time"
@@ -41,15 +40,6 @@ type fiveTuple struct {
 	srcPort uint16
 	dstAddr netip.Addr
 	dstPort uint16
-}
-
-func (ft fiveTuple) String() string {
-	return fmt.Sprintf(
-		"%s -> %s %s",
-		netip.AddrPortFrom(ft.srcAddr, ft.srcPort),
-		netip.AddrPortFrom(ft.dstAddr, ft.dstPort),
-		ft.proto,
-	)
 }
 
 // NewBlackholer creates a new [*Blackholer] instance.

--- a/netsim/censor/ip.go
+++ b/netsim/censor/ip.go
@@ -4,6 +4,7 @@ package censor
 
 import (
 	"bytes"
+	"fmt"
 	"net/netip"
 	"sync"
 	"time"
@@ -40,6 +41,15 @@ type fiveTuple struct {
 	srcPort uint16
 	dstAddr netip.Addr
 	dstPort uint16
+}
+
+func (ft fiveTuple) String() string {
+	return fmt.Sprintf(
+		"%s -> %s %s",
+		netip.AddrPortFrom(ft.srcAddr, ft.srcPort),
+		netip.AddrPortFrom(ft.dstAddr, ft.dstPort),
+		ft.proto,
+	)
 }
 
 // NewBlackholer creates a new [*Blackholer] instance.
@@ -101,4 +111,65 @@ func (t *Blackholer) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet
 	t.mu.Unlock()
 
 	return packet.DROP, nil
+}
+
+// DNatter implements transparent proxying via DNAT (Destination NAT).
+type DNatter struct {
+	// source is the source address to DNAT.
+	source netip.Addr
+
+	// target is the target destination endpoint to replace.
+	target netip.AddrPort
+
+	// repl is the replacement destination endpoint.
+	repl netip.AddrPort
+}
+
+// NewDNatter creates a new [*DNatter] instance.
+//
+// Arguments:
+//
+// - source is the source address to DNAT.
+//
+// - target is the target destination endpoint to replace.
+//
+// - repl is the replacement destination endpoint.
+//
+// For example, with:
+//
+// - source = "193.206.158.22"
+//
+// - target = "93.184.216.34:80"
+//
+// - repl = "10.10.34.35:80"
+//
+// Traffic from "192.206.168.22" to "93.184.216.34:80" will be sent
+// to "10.10.34.35:80" instead and return traffic from "10.10.345.35:80" to
+// "192.206.168.22" would seem to come from "93.184.216.34:80".
+func NewDNatter(source netip.Addr, target, repl netip.AddrPort) *DNatter {
+	return &DNatter{
+		source: source,
+		target: target,
+		repl:   repl,
+	}
+}
+
+// Filter implements [packet.Filter].
+func (r *DNatter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet) {
+	// forward match on the DNAT rule
+	if pkt.SrcAddr == r.source && (pkt.DstAddr == r.target.Addr() && pkt.DstPort == r.target.Port()) {
+		pkt.DstAddr = r.repl.Addr()
+		pkt.DstPort = r.repl.Port()
+		return packet.ACCEPT, nil
+	}
+
+	// return patch match on the DNAT rule
+	if (pkt.SrcAddr == r.repl.Addr() && pkt.SrcPort == r.repl.Port()) && pkt.DstAddr == r.source {
+		pkt.SrcAddr = r.target.Addr()
+		pkt.SrcPort = r.target.Port()
+		return packet.ACCEPT, nil
+	}
+
+	// otherwise just accept the packet
+	return packet.ACCEPT, nil
 }

--- a/netsim/example_censor_http_test.go
+++ b/netsim/example_censor_http_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netsim_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/netip"
+
+	"github.com/rbmk-project/x/netsim"
+	"github.com/rbmk-project/x/netsim/censor"
+)
+
+// This example shows how to use [netsim] to simulate transparent
+// proxying of HTTP requests to serve blockpages.
+func Example_blockpageTransparentProxy() {
+	// Create scenario
+	scenario := netsim.NewScenario("testdata")
+	defer scenario.Close()
+
+	// Create blockpage server
+	blockpage := scenario.MustNewBlockpageStack()
+	scenario.Attach(blockpage)
+
+	// Create target website
+	scenario.Attach(scenario.MustNewExampleComStack())
+
+	// Configure DNAT to send blocked traffic to blockpage server
+	scenario.Router().AddFilter(censor.NewDNatter(
+		netip.MustParseAddr("193.206.158.22"),       // source addr
+		netip.MustParseAddrPort("93.184.216.34:80"), // target dest epnt
+		netip.MustParseAddrPort("10.10.34.35:80"),   // repl dest epnt
+	))
+
+	// Create client stack
+	clientStack := scenario.MustNewClientStack()
+	scenario.Attach(clientStack)
+
+	// Create the HTTP client
+	clientTxp := scenario.NewHTTPTransport(clientStack)
+	defer clientTxp.CloseIdleConnections()
+	clientHTTP := &http.Client{Transport: clientTxp}
+
+	// Get the response body.
+	resp, err := clientHTTP.Get("http://93.184.216.34/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		log.Fatalf("HTTP request failed: %d", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the response body
+	fmt.Printf("%s", string(body))
+
+	// Output:
+	// Access to this website has been blocked by network policy.
+}

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -45,8 +45,7 @@ func (s *Scenario) MustNewExampleComStack() *Stack {
 			"2606:2800:21f:cb07:6820:80da:af6b:8b2c",
 			"93.184.216.34",
 		},
-		HTTPHandler:  handler,
-		HTTPSHandler: handler,
+		HTTPHandler: handler,
 	})
 }
 
@@ -69,5 +68,26 @@ func (s *Scenario) MustNewClientStack() *Stack {
 			"2001:4860:4860::8888",
 			"8.8.8.8",
 		},
+	})
+}
+
+// MustNewBlockpageStack creates a new stack simulating a censorship blockpage server.
+//
+// It serves a simple warning page on HTTP/HTTPS indicating that the content has been blocked.
+func (s *Scenario) MustNewBlockpageStack() *Stack {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Access to this website has been blocked by network policy.\n"))
+	})
+
+	return s.MustNewStack(&StackConfig{
+		DomainNames: []string{
+			"block.invalid", // Using .invalid TLD to avoid conflicts
+		},
+		Addresses: []string{
+			"10.10.34.35", // RFC1918 private address for blockpage server
+		},
+		HTTPHandler:  handler,
+		HTTPSHandler: handler,
 	})
 }

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -45,7 +45,8 @@ func (s *Scenario) MustNewExampleComStack() *Stack {
 			"2606:2800:21f:cb07:6820:80da:af6b:8b2c",
 			"93.184.216.34",
 		},
-		HTTPHandler: handler,
+		HTTPHandler:  handler,
+		HTTPSHandler: handler,
 	})
 }
 
@@ -87,7 +88,6 @@ func (s *Scenario) MustNewBlockpageStack() *Stack {
 		Addresses: []string{
 			"10.10.34.35", // RFC1918 private address for blockpage server
 		},
-		HTTPHandler:  handler,
-		HTTPSHandler: handler,
+		HTTPHandler: handler,
 	})
 }

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -82,11 +82,8 @@ func (s *Scenario) MustNewBlockpageStack() *Stack {
 	})
 
 	return s.MustNewStack(&StackConfig{
-		DomainNames: []string{
-			"block.invalid", // Using .invalid TLD to avoid conflicts
-		},
 		Addresses: []string{
-			"10.10.34.35", // RFC1918 private address for blockpage server
+			"10.10.34.35",
 		},
 		HTTPHandler: handler,
 	})


### PR DESCRIPTION
With DNAT censorship you can transparently rewrite

```
srcAddr:srcPort -> tgtAddr:tgtPort
```

to

```
srcAddr:srcPort -> replAddr:replPort
```

and back. This allows to capture all DNS traffic or all HTTP traffic and serve it from censored hosts.