### PR TITLE
fix: packet.ACCEPT => packet.CONTINUE

### DIFF
--- a/netsim/censor/doc.go
+++ b/netsim/censor/doc.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
+Package censor implements common internet censorship techniques for testing.
+
+This package provides filters that model different types of censorship:
+
+All filters implement the [packet.Filter] interface and can be composed to model
+complex censorship scenarios. The implementations focus on common real-world
+censorship techniques while remaining simple enough for testing purposes.
+
+# DNS Response Injection
+
+The [*DNSPoisoner]* type implements GFW-style DNS poisoning by injecting spoofed
+responses. It can target specific resolvers and is based on a database of poisoned
+responses to inject. Legitimate responses are allowed to pass through, thus the
+client is expected to receive multiple responses for each censored query.
+
+# TCP Reset Injection
+
+The [*TCPResetter] type implements RST-based connection disruption. It can match
+on specific patterns (e.g., TLS SNI) while allowing TCP handshakes to complete,
+modeling how real censors selectively terminate connections based on application
+layer content. Combining pattern matching and endpoint matching allows for modeling
+SNI+endpoint based blocking, which is another common censorship case.
+
+# Connection Blackholing
+
+The [*Blackholer] type implements connection blackholing with optional pattern
+matching. Once triggered, it blocks all packets for the matching connection
+for a configurable duration. This models censors that completely block specific
+traffic patterns or endpoints, causing timeouts. In addition, this filter can
+remember the blocked five tuples, thus causing residual censorship effects.
+
+# Destination NAT
+
+The [*DNatter] type implements transparent proxying through destination NAT
+(DNAT): it allows redirecting traffic from specific sources to alternative destinations
+while maintaining proper connection tracking. This models censors that redirect
+traffic to warning pages or surveillance systems.
+*/
+package censor

--- a/netsim/censor/doc.go
+++ b/netsim/censor/doc.go
@@ -11,7 +11,7 @@ censorship techniques while remaining simple enough for testing purposes.
 
 # DNS Response Injection
 
-The [*DNSPoisoner]* type implements GFW-style DNS poisoning by injecting spoofed
+The [*DNSPoisoner] type implements GFW-style DNS poisoning by injecting spoofed
 responses. It can target specific resolvers and is based on a database of poisoned
 responses to inject. Legitimate responses are allowed to pass through, thus the
 client is expected to receive multiple responses for each censored query.

--- a/netsim/censor/doc.go
+++ b/netsim/censor/doc.go
@@ -28,9 +28,9 @@ SNI+endpoint based blocking, which is another common censorship case.
 
 The [*Blackholer] type implements connection blackholing with optional pattern
 matching. Once triggered, it blocks all packets for the matching connection
-for a configurable duration. This models censors that completely block specific
-traffic patterns or endpoints, causing timeouts. In addition, this filter can
-remember the blocked five tuples, thus causing residual censorship effects.
+for a configurable duration, causing residual five-tuple censorship. This models
+censors that completely block specific traffic patterns or endpoints, causing
+I/O timeouts.
 
 # Destination NAT
 

--- a/netsim/censor/ip.go
+++ b/netsim/censor/ip.go
@@ -84,14 +84,14 @@ func (t *Blackholer) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet
 	// Check if we need to filter specific endpoint
 	if t.target.IsValid() {
 		if pkt.DstAddr != t.target.Addr() || pkt.DstPort != t.target.Port() {
-			return packet.ACCEPT, nil
+			return packet.CONTINUE, nil
 		}
 	}
 
 	// If we have a pattern, check payload
 	if t.pattern != nil {
 		if len(pkt.Payload) <= 0 || !bytes.Contains(pkt.Payload, t.pattern) {
-			return packet.ACCEPT, nil
+			return packet.CONTINUE, nil
 		}
 	}
 
@@ -150,16 +150,16 @@ func (r *DNatter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet) {
 	if pkt.SrcAddr == r.source && (pkt.DstAddr == r.target.Addr() && pkt.DstPort == r.target.Port()) {
 		pkt.DstAddr = r.repl.Addr()
 		pkt.DstPort = r.repl.Port()
-		return packet.ACCEPT, nil
+		return packet.CONTINUE, nil
 	}
 
 	// return patch match on the DNAT rule
 	if (pkt.SrcAddr == r.repl.Addr() && pkt.SrcPort == r.repl.Port()) && pkt.DstAddr == r.source {
 		pkt.SrcAddr = r.target.Addr()
 		pkt.SrcPort = r.target.Port()
-		return packet.ACCEPT, nil
+		return packet.CONTINUE, nil
 	}
 
 	// otherwise just accept the packet
-	return packet.ACCEPT, nil
+	return packet.CONTINUE, nil
 }

--- a/netsim/censor/tcp.go
+++ b/netsim/censor/tcp.go
@@ -42,13 +42,13 @@ func NewTCPResetter(target netip.AddrPort, pattern []byte) *TCPResetter {
 func (r *TCPResetter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packet) {
 	// Only process TCP packets
 	if pkt.IPProtocol != packet.IPProtocolTCP {
-		return packet.ACCEPT, nil
+		return packet.CONTINUE, nil
 	}
 
 	// Check if we need to filter a specific endpoint
 	if r.target.IsValid() {
 		if pkt.DstAddr != r.target.Addr() || pkt.DstPort != r.target.Port() {
-			return packet.ACCEPT, nil
+			return packet.CONTINUE, nil
 		}
 	}
 
@@ -57,7 +57,7 @@ func (r *TCPResetter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packe
 	// handshake to complete before potentially injecting RST.
 	if r.pattern != nil {
 		if len(pkt.Payload) <= 0 || !bytes.Contains(pkt.Payload, r.pattern) {
-			return packet.ACCEPT, nil
+			return packet.CONTINUE, nil
 		}
 	}
 
@@ -72,5 +72,5 @@ func (r *TCPResetter) Filter(pkt *packet.Packet) (packet.Target, []*packet.Packe
 		Flags:      packet.TCPFlagRST,
 	}
 
-	return packet.ACCEPT, []*packet.Packet{rst}
+	return packet.CONTINUE, []*packet.Packet{rst}
 }

--- a/netsim/packet/packet.go
+++ b/netsim/packet/packet.go
@@ -188,8 +188,8 @@ func NewNetworkDeviceIOChannels() (chan *Packet, chan *Packet) {
 type Target int
 
 const (
-	// ACCEPT lets the [*Packet] continue through the chain.
-	ACCEPT Target = iota
+	// CONTINUE lets the [*Packet] continue through the chain.
+	CONTINUE Target = iota
 
 	// DROP silently discards the [*Packet].
 	DROP


### PR DESCRIPTION
The target is non-terminating because it allows other filters to run, so avoid giving it a name that is used for a terminating target in iptables (`ACCEPT`) and use `CONTINUE` instead.

While there, add docs for `./netsim/censor`.