### PR TITLE
fix(netstack): resetNonblocking expects Flags == SYN

### DIFF
--- a/netsim/netstack/stack.go
+++ b/netsim/netstack/stack.go
@@ -185,7 +185,7 @@ func (ns *Stack) findPortLocked(pkt *Packet) *Port {
 // resetNonblocking sends a RST packet in response to a SYN for a closed port.
 func (ns *Stack) resetNonblocking(pkt *Packet) {
 	runtimex.Assert(pkt.IPProtocol == IPProtocolTCP, "not a TCP packet")
-	runtimex.Assert(pkt.Flags != TCPFlagSYN, "expected SYN flags")
+	runtimex.Assert(pkt.Flags == TCPFlagSYN, "expected SYN flags")
 	resp := &Packet{
 		SrcAddr:    pkt.DstAddr,
 		DstAddr:    pkt.SrcAddr,


### PR DESCRIPTION
The assertion, instead, was checking for the Flags != SYN, which caused an assertion when connecting to a closed port.