### PR TITLE
fix(netsim): forward return traffic via geolink

### DIFF
--- a/netsim/geolink/geolink.go
+++ b/netsim/geolink/geolink.go
@@ -27,15 +27,16 @@ type Config struct {
 // baseDevice is the common implementation for the
 // devices type returned by this package.
 type baseDevice struct {
-	input  chan *packet.Packet
-	output chan *packet.Packet
+	addresses []netip.Addr
+	input     chan *packet.Packet
+	output    chan *packet.Packet
 }
 
-func (*baseDevice) Addresses() []netip.Addr {
-	return nil
+func (dev *baseDevice) Addresses() []netip.Addr {
+	return dev.addresses
 }
 
-func (*baseDevice) EOF() <-chan struct{} {
+func (dev *baseDevice) EOF() <-chan struct{} {
 	return nil
 }
 
@@ -92,8 +93,9 @@ func (ed *externalDevice) Output() <-chan *packet.Packet {
 func Extend(dev packet.NetworkDevice, config *Config) packet.NetworkDevice {
 	input, output := packet.NewNetworkDeviceIOChannels()
 	local := &baseDevice{
-		input:  input,
-		output: output,
+		addresses: dev.Addresses(),
+		input:     input,
+		output:    output,
 	}
 	go forward(dev, &internalDevice{local}, config)
 	go forward(&internalDevice{local}, dev, config)

--- a/netsim/router/router.go
+++ b/netsim/router/router.go
@@ -39,16 +39,14 @@ func (r *Router) AddFilter(pf packet.Filter) {
 	r.filtermu.Unlock()
 }
 
-// Attach attaches a [packet.NetworkDevice] to the [*Router].
+// Attach attaches a [packet.NetworkDevice] to the [*Router] reading
+// packets from the router and setting up routes for all the device
+// addresses to correctly forward packets back to the device.
 func (r *Router) Attach(dev packet.NetworkDevice) {
-	go r.readLoop(dev)
-}
-
-// AddRoute adds routes for all addresses of the given [packet.NetworkDevice].
-func (r *Router) AddRoute(dev packet.NetworkDevice) {
 	for _, addr := range dev.Addresses() {
 		r.srt[addr] = dev
 	}
+	go r.readLoop(dev)
 }
 
 // readLoop reads packets from a [packet.NetworkDevice] until EOF.

--- a/netsim/scenario.go
+++ b/netsim/scenario.go
@@ -98,7 +98,9 @@ func (s *Scenario) Close() error {
 	return s.pool.Close()
 }
 
-// Attach connects a device to the scenario's central router.
+// Attach connects a device to the scenario's central router to
+// read packets from the device, and sets up the route to that
+// return packets correctly reach the device.
 //
 // The common case is to attach a [*Stack] but other cases are also
 // possible. Suppose a [*Stack] is linked to a firewall through a link,

--- a/netsim/setup.go
+++ b/netsim/setup.go
@@ -60,7 +60,6 @@ func (s *Scenario) newBaseStack(cfg *StackConfig) (*Stack, error) {
 		addrs[idx] = pa
 	}
 	stack := NewStack(addrs...)
-	s.router.AddRoute(stack)
 	return stack, nil
 }
 


### PR DESCRIPTION
The way in which we were adding a geolink to a stack was such that the return route was not routed through the geolink.

This was obvious when trying to print packets traversing the geolink.

To fix, rework how we attach a network device to a router:

1. combine reading from the device and setting up the return route into `(*Router).Attach` and dispose of `AddRoute`.

2. make sure we propagate the IP addresses of the device to the device at the other end of the geolink, so the router can use the `Addresses` getter to correctly setup routes.

Now, printing packets traversing the geolink correctly shows packets traveling on the return path.