### PR TITLE
feat(netsim): add DNS-over-TLS to scenario

### DIFF
--- a/netsim/example_dns_test.go
+++ b/netsim/example_dns_test.go
@@ -4,6 +4,7 @@ package netsim_test
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"time"
@@ -121,6 +122,77 @@ func Example_dnsOverTCP() {
 	// Perform the DNS round trip
 	clientDNS := &dns.Client{Net: "tcp"}
 	resp, _, err := clientDNS.ExchangeWithConnContext(ctx, query, &dns.Conn{Conn: conn})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the responses
+	for _, ans := range resp.Answer {
+		if a, ok := ans.(*dns.A); ok {
+			fmt.Printf("%s\n", a.A.String())
+		}
+	}
+
+	// Output:
+	// 8.8.8.8
+}
+
+// This example shows how to use [netsim] to simulate a DNS
+// server that listens for incoming requests over TLS.
+func Example_dnsOverTLS() {
+	// Create a new scenario using the given directory to cache
+	// the certificates used by the simulated PKI
+	scenario := netsim.NewScenario("testdata")
+	defer scenario.Close()
+
+	// Create server stack emulating dns.google.
+	//
+	// This includes:
+	//
+	// 1. creating, attaching, and enabling routing for a server stack
+	//
+	// 2. registering the proper domain names and addresses
+	//
+	// 3. updating the PKI database to include the server's certificate
+	scenario.Attach(scenario.MustNewGoogleDNSStack())
+
+	// Create and attach the client stack.
+	clientStack := scenario.MustNewClientStack()
+	scenario.Attach(clientStack)
+
+	// Create a context with a watchdog timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create the client connection with the DNS server.
+	conn, err := clientStack.DialContext(ctx, "tcp", "8.8.8.8:853")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	tconn := tls.Client(conn, &tls.Config{
+		RootCAs:    scenario.RootCAs(),
+		NextProtos: []string{"dot"},
+		ServerName: "dns.google",
+	})
+	defer tconn.Close()
+	if err := tconn.HandshakeContext(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	// Create the query to send
+	query := new(dns.Msg)
+	query.Id = dns.Id()
+	query.RecursionDesired = true
+	query.Question = []dns.Question{{
+		Name:   "dns.google.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	}}
+
+	// Perform the DNS round trip
+	clientDNS := &dns.Client{Net: "tcp-tls"}
+	resp, _, err := clientDNS.ExchangeWithConnContext(ctx, query, &dns.Conn{Conn: tconn})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/netsim/scenario.go
+++ b/netsim/scenario.go
@@ -82,6 +82,10 @@ func (s *Scenario) MustNewStack(config *StackConfig) *Stack {
 	if config.DNSOverTCPHandler != nil {
 		s.mustSetupDNSOverTCP(stack, config)
 	}
+	if config.DNSOverTLSHandler != nil {
+		runtimex.Assert(hasCert, "no TLS certificate available")
+		s.mustSetupDNSOverTLS(stack, config, cert)
+	}
 
 	// Start HTTP handlers.
 	if config.HTTPHandler != nil {

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -25,6 +25,7 @@ func (s *Scenario) MustNewGoogleDNSStack() *Stack {
 		},
 		DNSOverUDPHandler: s.DNSHandler(),
 		DNSOverTCPHandler: s.DNSHandler(),
+		DNSOverTLSHandler: s.DNSHandler(),
 		HTTPHandler:       handler,
 		HTTPSHandler:      handler,
 	})


### PR DESCRIPTION
Now we can use DNS-over-TLS as part of a scenario.