### PR TITLE
feat(netsim): add DNS-over-HTTPS to scenario

### DIFF
--- a/netsim/dns.go
+++ b/netsim/dns.go
@@ -2,7 +2,12 @@
 
 package netsim
 
-import "github.com/rbmk-project/x/netsim/dns"
+import (
+	"io"
+	"net/http"
+
+	"github.com/rbmk-project/x/netsim/dns"
+)
 
 // DNSHandler is an alias for [dns.Handler].
 type DNSHandler = dns.Handler
@@ -12,3 +17,15 @@ type dnsDatabase = dns.Database
 
 // newDNSDatabase is an alias for [dns.NewDatabase].
 var newDNSDatabase = dns.NewDatabase
+
+// NewDNSHTTPHandler returns an [http.Handler] handling DNS-over-HTTPS.
+func NewDNSHTTPHandler(dd dns.Database) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawQuery, err := io.ReadAll(r.Body)
+		if err != nil {
+			return
+		}
+		w.Header().Add("Content-Type", "application/dns-message")
+		dd.Handle(w, rawQuery)
+	})
+}

--- a/netsim/example_http_test.go
+++ b/netsim/example_http_test.go
@@ -19,7 +19,7 @@ func Example_http() {
 	scenario := netsim.NewScenario("testdata")
 	defer scenario.Close()
 
-	// Create server stack emulating dns.google.
+	// Create server stack emulating www.example.com.
 	//
 	// This includes:
 	//
@@ -28,7 +28,7 @@ func Example_http() {
 	// 2. registering the proper domain names and addresses
 	//
 	// 3. updating the PKI database to include the server's certificate
-	scenario.Attach(scenario.MustNewGoogleDNSStack())
+	scenario.Attach(scenario.MustNewExampleComStack())
 
 	// Create and attach the client stack.
 	clientStack := scenario.MustNewClientStack()
@@ -40,7 +40,7 @@ func Example_http() {
 	clientHTTP := &http.Client{Transport: clientTxp}
 
 	// Get the response body.
-	resp, err := clientHTTP.Get("http://8.8.8.8/")
+	resp, err := clientHTTP.Get("http://93.184.216.34/")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -57,5 +57,5 @@ func Example_http() {
 	fmt.Printf("%s", string(body))
 
 	// Output:
-	// Google Public DNS server.
+	// Example Web Server.
 }

--- a/netsim/wellknown.go
+++ b/netsim/wellknown.go
@@ -11,9 +11,11 @@ import "net/http"
 
 // MustNewGoogleDNSStack creates a new stack simulating dns.google.
 func (s *Scenario) MustNewGoogleDNSStack() *Stack {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("Google Public DNS server.\n"))
-	})
+	}))
+	mux.Handle("/dns-query", NewDNSHTTPHandler(*s.dnsd))
 	return s.MustNewStack(&StackConfig{
 		DomainNames: []string{
 			"dns.google",
@@ -26,8 +28,7 @@ func (s *Scenario) MustNewGoogleDNSStack() *Stack {
 		DNSOverUDPHandler: s.DNSHandler(),
 		DNSOverTCPHandler: s.DNSHandler(),
 		DNSOverTLSHandler: s.DNSHandler(),
-		HTTPHandler:       handler,
-		HTTPSHandler:      handler,
+		HTTPSHandler:      mux,
 	})
 }
 


### PR DESCRIPTION
Support creating simulated DNS-over-HTTPS scenarios.

While there, reckon that dns.google does not listen on 80/tcp.