### PR TITLE
fix(netcore): allow setting the cert pool for dialing TLS

### DIFF
--- a/netcore/network.go
+++ b/netcore/network.go
@@ -9,6 +9,7 @@ package netcore
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"log/slog"
 	"net"
 	"time"
@@ -40,6 +41,11 @@ type Network struct {
 	// NewTLSClientConn is the optional function to create a new TLS client
 	// connection. If this field is nil, we use the [crypto/tls] package.
 	NewTLSClientConn func(conn net.Conn, config *tls.Config) TLSConn
+
+	// RootCAs contains the optional [*x509.CertPool] used when
+	// creating TLS connections. If it is not set, we use the system's
+	// root CAs. This field is only used when the TLSConfig field is nil.
+	RootCAs *x509.CertPool
 
 	// TLSConfig is the TLS client config to use. If this field is nil, we
 	// will try to create a suitable config based on the network and address

--- a/netcore/tlsconfig.go
+++ b/netcore/tlsconfig.go
@@ -8,6 +8,7 @@ package netcore
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 )
 
@@ -18,19 +19,19 @@ func (nx *Network) tlsConfig(network, address string) (*tls.Config, error) {
 		config := nx.TLSConfig.Clone() // make sure we return a cloned config
 		return config, nil
 	}
-	return newTLSConfig(network, address)
+	return newTLSConfig(network, address, nx.RootCAs)
 }
 
 // newTLSConfig is a best-effort attempt at creating a suitable TLS config
 // for TCP and UDP transports using the network and address.
-func newTLSConfig(network, address string) (*tls.Config, error) {
+func newTLSConfig(network, address string, pool *x509.CertPool) (*tls.Config, error) {
 	sni, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
 	}
 
 	config := &tls.Config{
-		RootCAs:    nil, // TODO(bassosimone): bundle Mozilla CA store
+		RootCAs:    pool, // default to nil, which implies using the system root CAs
 		NextProtos: []string{},
 		ServerName: sni,
 	}


### PR DESCRIPTION
We need this functionality for running integration tests in rbmk.

When the new field is nil, fallback to the previous behaviour of using the system root CA pool.