### PR TITLE
chore: extract netipx package from dnscore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,17 @@ require (
 	github.com/rbmk-project/common v0.6.0
 	github.com/rbmk-project/dnscore v0.6.0
 	github.com/rogpeppe/go-internal v1.13.1
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.27.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.27.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,5 +24,7 @@ golang.org/x/text v0.20.0 h1:gK/Kv2otX8gz+wn7Rmb3vT96ZwuoxnQlY+HlJVj7Qug=
 golang.org/x/text v0.20.0/go.mod h1:D4IsuqiFMhST5bX19pQ9ikHC2GsaKyk/oF+pn3ducp4=
 golang.org/x/tools v0.27.0 h1:qEKojBykQkQ4EynWy4S8Weg69NumxKdn40Fce3uc/8o=
 golang.org/x/tools v0.27.0/go.mod h1:sUi0ZgbwW9ZPAq26Ekut+weQPR5eIM6GQLQ1Yjm1H0Q=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/netipx/netipx.go
+++ b/netipx/netipx.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package netipx contains [net/netip] extensions.
+package netipx
+
+import (
+	"net"
+	"net/netip"
+)
+
+// AddrToAddrPort converts a [net.Addr] to a [netip.AddrPort].
+//
+// If the input is nil or neither a [*net.TCPAddr] nor [*net.UDPAddr],
+// returns an unspecified IPv6 address with port 0.
+//
+// For [*net.TCPAddr] and [*net.UDPAddr] addresses, returns their
+// corresponding [netip.AddrPort] representation.
+func AddrToAddrPort(addr net.Addr) netip.AddrPort {
+	if addr == nil {
+		return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+	}
+	if tcp, ok := addr.(*net.TCPAddr); ok {
+		return tcp.AddrPort()
+	}
+	if udp, ok := addr.(*net.UDPAddr); ok {
+		return udp.AddrPort()
+	}
+	return netip.AddrPortFrom(netip.IPv6Unspecified(), 0)
+}

--- a/netipx/netipx_test.go
+++ b/netipx/netipx_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netipx_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/rbmk-project/x/netipx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddrToAddrPort(t *testing.T) {
+	tests := []struct {
+		name string
+		addr net.Addr
+		want netip.AddrPort
+	}{
+		{
+			name: "nil address",
+			addr: nil,
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+
+		{
+			name: "TCP address",
+			addr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:db8::1"),
+				Port: 1234,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::1]:1234"),
+		},
+
+		{
+			name: "UDP address",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("2001:db8::2"),
+				Port: 5678,
+			},
+			want: netip.MustParseAddrPort("[2001:db8::2]:5678"),
+		},
+
+		{
+			name: "other address type",
+			addr: &net.UnixAddr{},
+			want: netip.AddrPortFrom(netip.IPv6Unspecified(), 0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := netipx.AddrToAddrPort(tt.addr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This diff extracts the netipx package from dnscore and exports the AddrToAddrPort function.