### PR TITLE
feat(netcore): add tests for WrapConn

### DIFF
--- a/netcore/conn.go
+++ b/netcore/conn.go
@@ -72,7 +72,7 @@ type connWrapper struct {
 	closeonce sync.Once
 	conn      net.Conn
 	laddr     string
-	netx      *Network
+	netx      *Network // may contain nil logger!
 	protocol  string
 	raddr     string
 }


### PR DESCRIPTION
Let us make sure WrapConn correctly wraps the underlying netx and correctly deals with the conn returnning nil addresses w/o crashing, which is a pathologic edge case to keep into account.

While there, ensure the `maybeWrapConn` method correctly sets the wrapper's netx field, so we are sure logging will happen when it has been configured inside of the network we're passing as argument.

While there, make tests names more consistent with respect to whether funcs are public or private, and whether they are methods or not.