### PR TITLE
feat(netcore): add optional LookupHost timeout

### DIFF
--- a/netcore/dialer.go
+++ b/netcore/dialer.go
@@ -57,6 +57,8 @@ func (nx *Network) sequentialDial(
 
 // dialLog dials and emits structured logs.
 func (nx *Network) dialLog(ctx context.Context, network, address string) (net.Conn, error) {
+	// TODO(bassosimone): decide whether we want to enforce timeout here
+
 	// Emit structured event before the dial
 	t0 := nx.emitConnectStart(ctx, network, address)
 

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -59,6 +59,10 @@ type Network struct {
 	// WrapConn is an optional function to wrap a connection to emit
 	// structured logs. [WrapConn] is the default wrapper to use.
 	WrapConn func(ctx context.Context, netx *Network, conn net.Conn) net.Conn
+
+	// LookupHostTimeout is the optional timeout to use for limiting
+	// the maximum time spent resolving a domain name.
+	LookupHostTimeout time.Duration
 }
 
 // DefaultNetwork is the default [*Network] used by this package.

--- a/netcore/resolver.go
+++ b/netcore/resolver.go
@@ -46,7 +46,12 @@ func (nx *Network) maybeLookupHost(ctx context.Context, domain string) ([]string
 		return []string{domain}, nil
 	}
 
-	// TODO(bassosimone): decide whether we want to enforce timeout here
+	// Optionally enforce a timeout for the lookup
+	if nx.LookupHostTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, nx.LookupHostTimeout)
+		defer cancel()
+	}
 
 	// Emit structured event before the lookup
 	t0 := nx.emitLookupHostStart(ctx, domain)


### PR DESCRIPTION
This diff adds support for an optional LookupHost timeout.

One can use the context when they just want the overall operation to fail, but it's also possible to limit just the LookupHost.