### PR TITLE
feat(dialer): add optional DialContext timeout

### DIFF
--- a/netcore/dialer.go
+++ b/netcore/dialer.go
@@ -60,7 +60,12 @@ func (nx *Network) sequentialDial(
 
 // dialLog dials and emits structured logs.
 func (nx *Network) dialLog(ctx context.Context, network, address string) (net.Conn, error) {
-	// TODO(bassosimone): decide whether we want to enforce timeout here
+	// Optionally enforce timeout for connection establishment
+	if nx.DialContextTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, nx.DialContextTimeout)
+		defer cancel()
+	}
 
 	// Emit structured event before the dial
 	t0 := nx.emitConnectStart(ctx, network, address)

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -63,6 +63,10 @@ type Network struct {
 	// LookupHostTimeout is the optional timeout to use for limiting
 	// the maximum time spent resolving a domain name.
 	LookupHostTimeout time.Duration
+
+	// DialContextTimeout is the optional timeout to use for limiting
+	// the maximum time spent creating a single connection.
+	DialContextTimeout time.Duration
 }
 
 // DefaultNetwork is the default [*Network] used by this package.


### PR DESCRIPTION
Like we did for the LookupHost function, add a custom timeout optionally limiting the time to dial a single connection.

While there, test that `Network.dialLog` is WAI without a configured logger.