### PR TITLE
feat(netcore): use *net.Dialer *net.Resolver singletons

### DIFF
--- a/netcore/network.go
+++ b/netcore/network.go
@@ -80,7 +80,8 @@ type Network struct {
 	// name suggests, this function may either create a new [*net.Dialer]
 	// for each call or just return a singleton instance. When this method
 	// is not set, we use an internal, static [*net.Dialer] where
-	// support for Multipath TCP has been disabled.
+	// support for Multipath TCP has been disabled. We disable Multipath
+	// TCP because we focus on precise internet measurements.
 	NewDialerOrSingleton func() *net.Dialer
 }
 

--- a/netcore/network.go
+++ b/netcore/network.go
@@ -67,6 +67,21 @@ type Network struct {
 	// DialContextTimeout is the optional timeout to use for limiting
 	// the maximum time spent creating a single connection.
 	DialContextTimeout time.Duration
+
+	// NewResolverOrSingleton is the optional function that returns
+	// the [*net.Resolver] to use when LookupHostFunc is not set. As the
+	// name suggests, this function may either create a new [*net.Resolver]
+	// for each call or just return a singleton instance. When this method
+	// is not set, we use an internal zero-initialized, static [*net.Resolver].
+	NewResolverOrSingleton func() *net.Resolver
+
+	// NewDialerOrSingleton is the optional function that returns
+	// the [*net.Dialer] to use when DialContextFunc is not set. As the
+	// name suggests, this function may either create a new [*net.Dialer]
+	// for each call or just return a singleton instance. When this method
+	// is not set, we use an internal, static [*net.Dialer] where
+	// support for Multipath TCP has been disabled.
+	NewDialerOrSingleton func() *net.Dialer
 }
 
 // DefaultNetwork is the default [*Network] used by this package.

--- a/netcore/resolver_test.go
+++ b/netcore/resolver_test.go
@@ -101,19 +101,16 @@ func TestNetwork_maybeLookupHost(t *testing.T) {
 	})
 
 	t.Run("system resolver error", func(t *testing.T) {
-		// Temporarily override maybeEditResolver and restore it when done
-		maybeEditResolver = func(reso *net.Resolver) *net.Resolver {
-			reso.PreferGo = true
-			reso.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
-				return nil, errors.New("mocked dial error")
-			}
-			return reso
+		nx := &Network{
+			NewResolverOrSingleton: func() *net.Resolver {
+				reso := &net.Resolver{}
+				reso.PreferGo = true
+				reso.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+					return nil, errors.New("mocked dial error")
+				}
+				return reso
+			},
 		}
-		defer func() {
-			maybeEditResolver = avoidEditingResolver
-		}()
-
-		nx := &Network{}
 		_, err := nx.maybeLookupHost(context.Background(), "example.com")
 		assert.Error(t, err)
 	})


### PR DESCRIPTION
Rather than creating a new instance for each dialing attempt, which may create unnecessary GC pressure, allow for using singletons. However, also allow for customising the `*net.Dialer` and/or `*net.Resolver` to use, via optional functions.