### PR TITLE
feat: start measuring code coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  build_and_test:
     strategy:
       matrix:
         goversion:
@@ -32,4 +32,25 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test -race -cover ./...
+        run: go test -race ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Here we should use the current go version
+          go-version: "1.24"
+
+      - name: Measure Coverage
+        run: go test -short -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.out
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Experimental libraries
 
-[![GoDoc](https://pkg.go.dev/badge/github.com/rbmk-project/x)](https://pkg.go.dev/github.com/rbmk-project/x)
+[![GoDoc](https://pkg.go.dev/badge/github.com/rbmk-project/x)](https://pkg.go.dev/github.com/rbmk-project/x) [![Build Status](https://github.com/rbmk-project/x/actions/workflows/go.yml/badge.svg)](https://github.com/rbmk-project/x/actions) [![codecov](https://codecov.io/gh/rbmk-project/x/branch/main/graph/badge.svg)](https://codecov.io/gh/rbmk-project/x)
 
 This repository contains several experimental libraries
 reused across different [rbmk](https://github.com/rbmk-project)


### PR DESCRIPTION
This diff adapts https://github.com/rbmk-project/common/pull/29 to this repository and includes the fix to use `-short` to avoid measuring the code coverage of integration tests, which was added in https://github.com/rbmk-project/common/pull/31.