### PR TITLE
fix(netcore): allow for utls-aware structured logs

### DIFF
--- a/netcore/network.go
+++ b/netcore/network.go
@@ -40,6 +40,14 @@ type Network struct {
 
 	// NewTLSClientConn is the optional function to create a new TLS client
 	// connection. If this field is nil, we use the [crypto/tls] package.
+	//
+	// If this field is not nil and TLSEngine is also not nil, the latter
+	// will take precedence in creating a new [TLSConn].
+	//
+	// When using this field, the "tlsEngineName" and "tlsParrot" fields
+	// in the structured logs will both be set to "unknown".
+	//
+	// Deprecated: use the TLSEngine field instead.
 	NewTLSClientConn func(conn net.Conn, config *tls.Config) TLSConn
 
 	// RootCAs contains the optional [*x509.CertPool] used when
@@ -83,6 +91,11 @@ type Network struct {
 	// support for Multipath TCP has been disabled. We disable Multipath
 	// TCP because we focus on precise internet measurements.
 	NewDialerOrSingleton func() *net.Dialer
+
+	// TLSEngine is the optional [TLSEngine] to use for creating a new
+	// instance of [TLSConn]. If this field is nil, we create on the fly
+	// and use an instance of [TLSEngineStdlib].
+	TLSEngine TLSEngine
 }
 
 // DefaultNetwork is the default [*Network] used by this package.

--- a/netcore/tlsdialer_test.go
+++ b/netcore/tlsdialer_test.go
@@ -251,6 +251,8 @@ func Test_tlsDialer_dial(t *testing.T) {
 				assert.Equal(t, "127.0.0.1:1234", logMap["localAddr"])
 				assert.Equal(t, "tcp", logMap["protocol"])
 				assert.Equal(t, "example.com:443", logMap["remoteAddr"])
+				assert.Equal(t, "unknown", logMap["tlsEngineName"])
+				assert.Equal(t, "unknown", logMap["tlsParrot"])
 				assert.Equal(t, "example.com", logMap["tlsServerName"])
 				assert.Equal(t, false, logMap["tlsSkipVerify"])
 			} else if logMap["msg"] == "tlsHandshakeDone" {
@@ -260,6 +262,8 @@ func Test_tlsDialer_dial(t *testing.T) {
 				assert.Equal(t, "127.0.0.1:1234", logMap["localAddr"])
 				assert.Equal(t, "tcp", logMap["protocol"])
 				assert.Equal(t, "example.com:443", logMap["remoteAddr"])
+				assert.Equal(t, "unknown", logMap["tlsEngineName"])
+				assert.Equal(t, "unknown", logMap["tlsParrot"])
 				assert.Equal(t, "", logMap["tlsNegotiatedProtocol"])
 				assert.Equal(t, "example.com", logMap["tlsServerName"])
 				assert.Equal(t, false, logMap["tlsSkipVerify"])

--- a/netcore/tlsengine.go
+++ b/netcore/tlsengine.go
@@ -1,0 +1,81 @@
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Adapted from: https://github.com/ooni/probe-cli/blob/v3.20.1/internal/netxlite/tls.go
+//
+
+package netcore
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// TLSEngine provides methods to create and describe [TLSConn] instances.
+type TLSEngine interface {
+	// Name returns the TLS engine name (e.g., "stdlib", "utls").
+	Name() string
+
+	// NewClientConn creates a new [TLSConn] instance.
+	NewClientConn(conn net.Conn, config *tls.Config) TLSConn
+
+	// Parrot returns the fingerprint we're parroting (e.g., "chrome",
+	// "firefox") or an empty string if there's no parroting.
+	Parrot() string
+}
+
+// newTLSEngine creates a new [TLSEngine] instance.
+func (nx *Network) newTLSEngine() TLSEngine {
+	switch {
+	case nx.TLSEngine != nil:
+		return nx.TLSEngine
+	case nx.NewTLSClientConn != nil:
+		return tlsEngineUnknown(nx.NewTLSClientConn)
+	default:
+		return &TLSEngineStdlib{}
+	}
+}
+
+// TLSEngineStdlib is a [TLSEngine] using the Go standard library.
+type TLSEngineStdlib struct{}
+
+// Ensure that [*TLSEngineStdlib] implements [TLSEngine].
+var _ TLSEngine = &TLSEngineStdlib{}
+
+// Name implements [TLSEngine] and returns "stdlib".
+func (*TLSEngineStdlib) Name() string {
+	return "stdlib"
+}
+
+// NewClientConn implements [TLSEngine] and uses the standard
+// library [tls.Client] function to create a [TLSConn].
+func (*TLSEngineStdlib) NewClientConn(conn net.Conn, config *tls.Config) TLSConn {
+	return tls.Client(conn, config)
+}
+
+// Parrot implements [TLSEngine] and returns an empty string.
+func (*TLSEngineStdlib) Parrot() string {
+	return ""
+}
+
+// tlsEngineUnknown is an adapter that turns a legacy NewTLSClientConn function
+// into a [TLSEngine] implementation with "unknown" metadata values.
+type tlsEngineUnknown func(conn net.Conn, config *tls.Config) TLSConn
+
+// Ensure that [tlsEngineUnknown] implements [TLSEngine].
+var _ TLSEngine = tlsEngineUnknown(nil)
+
+// Name implements [TLSEngine].
+func (t tlsEngineUnknown) Name() string {
+	return "unknown"
+}
+
+// NewClientConn implements [TLSEngine].
+func (t tlsEngineUnknown) NewClientConn(conn net.Conn, config *tls.Config) TLSConn {
+	return t(conn, config)
+}
+
+// Parrot implements [TLSEngine].
+func (t tlsEngineUnknown) Parrot() string {
+	return "unknown"
+}

--- a/netcore/tlsengine_test.go
+++ b/netcore/tlsengine_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package netcore
+
+import (
+	"crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// tlsEngineMock is a mocked [TLSEngine] used for testing.
+type tlsEngineMock struct{}
+
+var _ TLSEngine = &tlsEngineMock{}
+
+// Name implements TLSEngine.
+func (t *tlsEngineMock) Name() string {
+	panic("unimplemented")
+}
+
+// NewClientConn implements TLSEngine.
+func (t *tlsEngineMock) NewClientConn(conn net.Conn, config *tls.Config) TLSConn {
+	panic("unimplemented")
+}
+
+// Parrot implements TLSEngine.
+func (t *tlsEngineMock) Parrot() string {
+	panic("unimplemented")
+}
+
+func TestNetwork_newTLSEngine(t *testing.T) {
+	t.Run("when we have a custom TLSEngine", func(t *testing.T) {
+		nx := &Network{
+			TLSEngine: &tlsEngineMock{},
+		}
+		engine := nx.newTLSEngine()
+		_, ok := engine.(*tlsEngineMock)
+		assert.True(t, ok)
+	})
+
+	t.Run("when we have a custom NewTLSClientConn", func(t *testing.T) {
+		nx := &Network{
+			NewTLSClientConn: func(conn net.Conn, config *tls.Config) TLSConn {
+				panic("unimplemented")
+			},
+		}
+		engine := nx.newTLSEngine()
+		name := engine.Name()
+		assert.Equal(t, name, "unknown")
+	})
+
+	t.Run("when we have both TLSEngine and NewTLSClientConn", func(t *testing.T) {
+		nx := &Network{
+			TLSEngine: &tlsEngineMock{},
+			NewTLSClientConn: func(conn net.Conn, config *tls.Config) TLSConn {
+				panic("unimplemented")
+			},
+		}
+		engine := nx.newTLSEngine()
+		_, ok := engine.(*tlsEngineMock)
+		assert.True(t, ok)
+	})
+
+	t.Run("when nothing has been configured", func(t *testing.T) {
+		nx := &Network{}
+		engine := nx.newTLSEngine()
+		_, ok := engine.(*TLSEngineStdlib)
+		assert.True(t, ok)
+	})
+}

--- a/netcore/tlsengine_test.go
+++ b/netcore/tlsengine_test.go
@@ -3,10 +3,13 @@
 package netcore
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"testing"
 
+	"github.com/rbmk-project/common/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,41 +20,76 @@ var _ TLSEngine = &tlsEngineMock{}
 
 // Name implements [TLSEngine].
 func (t *tlsEngineMock) Name() string {
-	panic("unimplemented")
+	return "mock"
 }
 
 // NewClientConn implements [TLSEngine].
 func (t *tlsEngineMock) NewClientConn(conn net.Conn, config *tls.Config) TLSConn {
-	panic("unimplemented")
+	return &mocks.TLSConn{}
 }
 
 // Parrot implements [TLSEngine].
 func (t *tlsEngineMock) Parrot() string {
-	panic("unimplemented")
+	return "parrot"
 }
 
 func TestNetwork_newTLSEngine(t *testing.T) {
 	t.Run("when we have a custom TLSEngine", func(t *testing.T) {
+		// setup with mocked engine
 		nx := &Network{
 			TLSEngine: &tlsEngineMock{},
 		}
+
+		// obtain the engine and check on its type
 		engine := nx.newTLSEngine()
 		_, ok := engine.(*tlsEngineMock)
 		assert.True(t, ok)
+
+		// verify that the name is correct
+		assert.Equal(t, engine.Name(), "mock")
+
+		// verify that the conn is of the correct type
+		conn := engine.NewClientConn(&mocks.Conn{}, &tls.Config{})
+		_, ok = conn.(*mocks.TLSConn)
+		assert.True(t, ok)
+
+		// verify that the engine parrot is correct
+		assert.Equal(t, engine.Parrot(), "parrot")
 	})
 
 	t.Run("when we have a custom NewTLSClientConn", func(t *testing.T) {
+		// setup with mocked func
 		nx := &Network{
 			NewTLSClientConn: func(conn net.Conn, config *tls.Config) TLSConn {
-				panic("unimplemented")
+				return &mocks.TLSConn{
+					MockHandshakeContext: func(ctx context.Context) error {
+						return errors.New("mocked error")
+					},
+				}
 			},
 		}
+
+		// obtain the engine - we cannot check the type
+		// of the engine since it's a function
 		engine := nx.newTLSEngine()
+
+		// verify that the name is correct
 		name := engine.Name()
 		assert.Equal(t, name, "unknown")
+
+		// verify that the conn handshake returns an error
+		conn := engine.NewClientConn(&mocks.Conn{}, &tls.Config{})
+		err := conn.HandshakeContext(context.Background())
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "mocked error")
+
+		// verify that the engine parrot is correct
+		assert.Equal(t, engine.Parrot(), "unknown")
 	})
 
 	t.Run("when we have both TLSEngine and NewTLSClientConn", func(t *testing.T) {
+		// It suffices to ensure that the custom TLSEngine is used
+		// since we already extensively test it above
 		nx := &Network{
 			TLSEngine: &tlsEngineMock{},
 			NewTLSClientConn: func(conn net.Conn, config *tls.Config) TLSConn {
@@ -64,9 +102,22 @@ func TestNetwork_newTLSEngine(t *testing.T) {
 	})
 
 	t.Run("when nothing has been configured", func(t *testing.T) {
+		// setup an empty network
 		nx := &Network{}
+
+		// obtain the engine and check on its type
 		engine := nx.newTLSEngine()
 		_, ok := engine.(*TLSEngineStdlib)
 		assert.True(t, ok)
+
+		// verify that the name is correct
+		assert.Equal(t, engine.Name(), "stdlib")
+
+		// verify that the conn is of the correct type
+		conn := engine.NewClientConn(&mocks.Conn{}, &tls.Config{})
+		_, ok = conn.(*tls.Conn)
+
+		// verify that the engine parrot is correct
+		assert.Equal(t, engine.Parrot(), "")
 	})
 }

--- a/netcore/tlsengine_test.go
+++ b/netcore/tlsengine_test.go
@@ -15,17 +15,17 @@ type tlsEngineMock struct{}
 
 var _ TLSEngine = &tlsEngineMock{}
 
-// Name implements TLSEngine.
+// Name implements [TLSEngine].
 func (t *tlsEngineMock) Name() string {
 	panic("unimplemented")
 }
 
-// NewClientConn implements TLSEngine.
+// NewClientConn implements [TLSEngine].
 func (t *tlsEngineMock) NewClientConn(conn net.Conn, config *tls.Config) TLSConn {
 	panic("unimplemented")
 }
 
-// Parrot implements TLSEngine.
+// Parrot implements [TLSEngine].
 func (t *tlsEngineMock) Parrot() string {
 	panic("unimplemented")
 }


### PR DESCRIPTION
This diff modifies `Network` in a backwards compatible way to add a new optionally-nil field named `TLSEngine`.

This field is now the preferred way for creating a new `TLSConn` while the previous `NewTLSClientConn` field, which is still supported, has now become deprecated.

The problem we want to solve is that of making sure the name of the TLS engine and the parrot being used are inside of the structured logs.

With `TLSEngine`, which is an interface, we know that, via the `Name()` and `Parrot()` methods.

With `NewTLSClientConn`, we don't know, hence we set both to `"unknown"`.